### PR TITLE
Genicam autogeneration of DB and screens

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,8 +60,6 @@
         // we also mount the project folder into a know location in the container
         // this is where the ibek-support and ioc folders reside in the container build
         // in this way the devcontainer and runtime look very similar
-        "source=${localWorkspaceFolder},target=/epics/generic-source,type=bind",
-        // mounting this helps with running phoebus outside the container
-        "source=${localWorkspaceFolder}/.generated-bobs,target=/epics/opi,type=bind"
+        "source=${localWorkspaceFolder},target=/epics/generic-source,type=bind"
     ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,6 +60,8 @@
         // we also mount the project folder into a know location in the container
         // this is where the ibek-support and ioc folders reside in the container build
         // in this way the devcontainer and runtime look very similar
-        "source=${localWorkspaceFolder},target=/epics/generic-source,type=bind"
+        "source=${localWorkspaceFolder},target=/epics/generic-source,type=bind",
+        // mounting this helps with running phoebus outside the container
+        "source=${localWorkspaceFolder}/.generated-bobs,target=/epics/opi,type=bind"
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@ ioc/config
 # TODO this entry does not work - why on earth not?
 ioc/configure/CONFIG_SITE.Common.linux-x86_64
 
-# external generated bob folder TODO probalby will replace this with compose
-.generated-bobs

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ ioc/config
 # this gets updated during RTEMS builds in devcontainer but we dont want to commit it
 # TODO this entry does not work - why on earth not?
 ioc/configure/CONFIG_SITE.Common.linux-x86_64
+
+# external generated bob folder TODO probalby will replace this with compose
+.generated-bobs

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG DEVELOPER=${REGISTRY}/epics-base${IMAGE_EXT}-developer:${BASE}
 ##### build stage ##############################################################
 FROM  ${DEVELOPER} AS developer
 
+# Add missing dependancies
+RUN curl -o /usr/bin/yq -L https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_amd64 && chmod +x /usr/bin/yq
+
 # The devcontainer mounts the project root to /epics/generic-source
 # Using the same location here makes devcontainer/runtime differences transparent.
 ENV SOURCE_FOLDER=/epics/generic-source
@@ -68,6 +71,7 @@ FROM ${RUNTIME} AS runtime
 
 # get runtime assets from the preparation stage
 COPY --from=runtime_prep /assets /
+COPY --from=runtime_prep /usr/bin/yq /usr/bin/yq
 
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,8 @@ COPY --from=runtime_prep /assets /
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
 # allow generated genicam files to be written for non root runtime user id
-RUN chmod a+rw /epics/pvi-defs /epics/support/ADGenICam/db
+RUN chmod a+rw -R /epics/pvi-defs /epics/support/ADGenICam/db \
+    /epics/generic-source/ibek-support
 
 CMD ["bash", "-c", "${IOC}/start.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ COPY --from=runtime_prep /assets /
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
-RUN chmod a+rw /epics/pvi-defs
+# allow generated genicam files to be written for non root runtime user id
+RUN chmod a+rw /epics/pvi-defs /epics/support/ADGenICam/db
 
 CMD ["bash", "-c", "${IOC}/start.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ COPY --from=runtime_prep /assets /
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
+RUN chmod a+rw /epics/pvi-defs
+
 CMD ["bash", "-c", "${IOC}/start.sh"]
 
 

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -128,6 +128,12 @@ elif [ -f ${ibek_src} ]; then
     db_src=${RUNTIME_DIR}/ioc.subst
     final_ioc_startup=${RUNTIME_DIR}/st.cmd
 
+    # Auto generate GenICam database
+    instance_id=$(grep -oP "(?<=ID:\s).*" /epics/ioc/config/ioc.yaml)  # https://regex101.com/r/358gq3/1
+    arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
+    python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template
+    pvi convert device --template /tmp/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
+
     # get the ibek support yaml files this ioc's support modules
     defs=/epics/ibek-defs/*.ibek.support.yaml
     ibek runtime generate ${ibek_src} ${defs}

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -129,7 +129,7 @@ elif [ -f ${ibek_src} ]; then
     final_ioc_startup=${RUNTIME_DIR}/st.cmd
 
     # Auto generate GenICam database
-    instance_id=$(grep -oP "(?<=ID:\s).*" ${ibek_src})  # https://regex101.com/r/358gq3/1
+    instance_id=$(grep -oP "(?<=ID:\s).*" ${ibek_src}) || true  # https://regex101.com/r/358gq3/1
     if [ -n "$instance_id" ]; then
         arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
         python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -144,7 +144,14 @@ elif [ -f ${ibek_src} ]; then
         # Generate pvi device from the GenICam DB
         pvi convert device --template /epics/support/ADGenICam/db/$instance_class.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
         mv /epics/pvi-defs/ADGenICam.pvi.device.yaml /epics/pvi-defs/$instance_class.pvi.device.yaml
+        # change the title of the pvi device to match the camera ID
+        sed -i "s/arvFeature/Aravis $instance_id/g" /epics/pvi-defs/ADAravis.pvi.device.yaml
+        sed -i "s/label: ADGenICam/label: GenICam $instance_id/g" /epics/pvi-defs/$instance_class.pvi.device.yaml
+        # remove ADDriver from GenICam device
+        sed -i "/ADDriver//d" /epics/pvi-defs/$instance_class.pvi.device.yaml
     fi
+    # TODO: pvi changes should allow us to remove the last 3 sed lines above
+    # a) you will be able to specify no paretn, b) you will be able to specify the label
 
     # get the ibek support yaml files this ioc's support modules
     defs=/epics/ibek-defs/*.ibek.support.yaml

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -130,9 +130,11 @@ elif [ -f ${ibek_src} ]; then
 
     # Auto generate GenICam database
     instance_id=$(grep -oP "(?<=ID:\s).*" ${ibek_src})  # https://regex101.com/r/358gq3/1
-    arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
-    python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template
-    pvi convert device --template /tmp/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
+    if [ -n "$instance_id" ]; then
+        arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
+        python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template
+        pvi convert device --template /tmp/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
+    fi
 
     # get the ibek support yaml files this ioc's support modules
     defs=/epics/ibek-defs/*.ibek.support.yaml

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -128,30 +128,32 @@ elif [ -f ${ibek_src} ]; then
     db_src=${RUNTIME_DIR}/ioc.subst
     final_ioc_startup=${RUNTIME_DIR}/st.cmd
 
-    # Find address (ID) and CLASS of the first camera in the IOC instance yaml.
-    # NOTE this does not support mixed types of cameras in the same IOC
-    # ONE camera per IOC instance is recommended
-    # Multiple cameras of the same type are supported
-    # Mixed cameras will work but may not expose all their GenICam config parameters
-    instance_class=$(grep -m1 -oP "(?<=CLASS:\s).*" ${ibek_src}) || true  # https://regex101.com/r/358gq3/1
-    instance_id=$(grep -m1 -oP "(?<=ID:\s).*" ${ibek_src}) || true  # https://regex101.com/r/358gq3/1
-    if [[ -n $instance_id ]]; then
-        if [[ $instance_class == "AutoADGenICam" ]]; then
-            # Auto generate GenICam database from camera parameters XML
-            arv-tool-0.8 -a ${instance_id} genicam > /tmp/genicam.xml
-            python /epics/support/ADGenICam/scripts/makeDb.py /tmp/genicam.xml /epics/support/ADGenICam/db/AutoADGenICam.template
+    readarray entities < <(yq -o=j -I=0 '.entities[]' ${ibek_src})
+    for ((count = 0 ; count < ${#entities[@]} ; count++ ))  # Interate over each entity
+    do
+        instance_type=$(yq .entities[${count}].type ${ibek_src})
+        if [ $instance_type = "ADAravis.aravisCamera" ]
+        then
+            instance_class=$(yq .entities[${count}].CLASS ${ibek_src})
+            instance_id=$(yq .entities[${count}].ID ${ibek_src})
+
+            if [[ $instance_class == "AutoADGenICam" ]]; then
+                instance_class=${instance_id}-${instance_class}
+                # Auto generate GenICam database from camera parameters XML
+                arv-tool-0.8 -a ${instance_id} genicam > /tmp/${instance_id}-genicam.xml
+                python /epics/support/ADGenICam/scripts/makeDb.py /tmp/${instance_id}-genicam.xml /epics/support/ADGenICam/db/${instance_class}.template
+            fi
+            # Generate pvi device from the GenICam DB
+            pvi convert device --template /epics/support/ADGenICam/db/$instance_class.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
+            mv /epics/pvi-defs/ADGenICam.pvi.device.yaml /epics/pvi-defs/$instance_class.pvi.device.yaml
+            # change the title of the pvi device to match the camera ID
+            sed -i "s/label: ADGenICam/label: GenICam $instance_id/g" /epics/pvi-defs/$instance_class.pvi.device.yaml
+            # remove ADDriver from GenICam device
+            sed -i "s/ADDriver//" /epics/pvi-defs/$instance_class.pvi.device.yaml
+            # TODO: pvi changes should allow us to remove the last 2 sed lines above
+            # a) you will be able to specify no parent, b) you will be able to specify the label
         fi
-        # Generate pvi device from the GenICam DB
-        pvi convert device --template /epics/support/ADGenICam/db/$instance_class.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
-        mv /epics/pvi-defs/ADGenICam.pvi.device.yaml /epics/pvi-defs/$instance_class.pvi.device.yaml
-        # change the title of the pvi device to match the camera ID
-        sed -i "s/arvFeature/Aravis $instance_id/g" /epics/pvi-defs/ADAravis.pvi.device.yaml
-        sed -i "s/label: ADGenICam/label: GenICam $instance_id/g" /epics/pvi-defs/$instance_class.pvi.device.yaml
-        # remove ADDriver from GenICam device
-        sed -i "s/ADDriver//" /epics/pvi-defs/$instance_class.pvi.device.yaml
-    fi
-    # TODO: pvi changes should allow us to remove the last 3 sed lines above
-    # a) you will be able to specify no paretn, b) you will be able to specify the label
+    done
 
     # get the ibek support yaml files this ioc's support modules
     defs=/epics/ibek-defs/*.ibek.support.yaml

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -148,7 +148,7 @@ elif [ -f ${ibek_src} ]; then
         sed -i "s/arvFeature/Aravis $instance_id/g" /epics/pvi-defs/ADAravis.pvi.device.yaml
         sed -i "s/label: ADGenICam/label: GenICam $instance_id/g" /epics/pvi-defs/$instance_class.pvi.device.yaml
         # remove ADDriver from GenICam device
-        sed -i "/ADDriver//d" /epics/pvi-defs/$instance_class.pvi.device.yaml
+        sed -i "s/ADDriver//" /epics/pvi-defs/$instance_class.pvi.device.yaml
     fi
     # TODO: pvi changes should allow us to remove the last 3 sed lines above
     # a) you will be able to specify no paretn, b) you will be able to specify the label

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -120,7 +120,7 @@ if [ -f ${override} ]; then
 # 2. ioc.yaml ******************************************************************
 elif [ -f ${ibek_src} ]; then
 
-    if [[ ${#ibek_yams[@]} > 1 ]]; then
+    if [[ ${#ibek_yamls[@]} > 1 ]]; then
         ibek_error "ERROR: Multiple YAML files found in ${CONFIG_DIR}."
     fi
 
@@ -129,7 +129,7 @@ elif [ -f ${ibek_src} ]; then
     final_ioc_startup=${RUNTIME_DIR}/st.cmd
 
     # Auto generate GenICam database
-    instance_id=$(grep -oP "(?<=ID:\s).*" /epics/ioc/config/ioc.yaml)  # https://regex101.com/r/358gq3/1
+    instance_id=$(grep -oP "(?<=ID:\s).*" ${ibek_src})  # https://regex101.com/r/358gq3/1
     arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
     python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template
     pvi convert device --template /tmp/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -131,9 +131,10 @@ elif [ -f ${ibek_src} ]; then
     # Auto generate GenICam database
     instance_id=$(grep -oP "(?<=ID:\s).*" ${ibek_src}) || true  # https://regex101.com/r/358gq3/1
     if [ -n "$instance_id" ]; then
-        arv-tool-0.8 -a ${instance_id} genicam > /epics/runtime/genicam.xml
-        python /epics/support/ADGenICam/scripts/makeDb.py /epics/runtime/genicam.xml /tmp/genicam.template
-        pvi convert device --template /tmp/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
+        mkdir -p /tmp/genicam
+        arv-tool-0.8 -a ${instance_id} genicam > /tmp/genicam/genicam.xml
+        python /epics/support/ADGenICam/scripts/makeDb.py /tmp/genicam/genicam.xml /tmp/genicam/genicam.template
+        pvi convert device --template /tmp/genicam/genicam.template /epics/pvi-defs/ /epics/support/ADGenICam/include/ADGenICam.h
     fi
 
     # get the ibek support yaml files this ioc's support modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ibek==3.0.0
+ibek==3.0.1
 # to install direct from github during development in a branch
-# git+https://github.com/epics-containers/ibek.git@fix-extract-assets
+# ibek@git+https://github.com/epics-containers/ibek.git@branch


### PR DESCRIPTION
Auto generation of database template, pvi device and bob screens from the genicam XML extracted from the camera itself.

To use this set 'CLASS' to AutoADGenICam. We still support CLASS being one of the predefined templates in the ADGenIcam module in which case that is used but the pvi is still auto generated from that.

@GDYendell note that I'm manually patching things right now with sed, but as per https://github.com/epics-containers/pvi/issues/120 I hope to drop these once a new version of PVI is available. See the following comments for what I hope to see changed in PVI:
https://github.com/epics-containers/ioc-adaravis/blob/57bd5b28a12cb5c2e237caee15670602481c1341/ioc/start.sh#L146-L154

Also note I fell back to supporting only one type of camera per IOC - all the corner cases were getting too fiddly for a feature we don't need. 
https://github.com/epics-containers/ioc-adaravis/blob/57bd5b28a12cb5c2e237caee15670602481c1341/ioc/start.sh#L131-L136

Will squash merge this.