### PR TITLE
update genicam template names and cope with missing camera with auto-gen

### DIFF
--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -138,10 +138,16 @@ elif [ -f ${ibek_src} ]; then
             instance_id=$(yq .entities[${count}].ID ${ibek_src})
 
             if [[ $instance_class == "AutoADGenICam" ]]; then
-                instance_class=${instance_id}-${instance_class}
+                instance_class=auto-${instance_id}
                 # Auto generate GenICam database from camera parameters XML
                 arv-tool-0.8 -a ${instance_id} genicam > /tmp/${instance_id}-genicam.xml
-                python /epics/support/ADGenICam/scripts/makeDb.py /tmp/${instance_id}-genicam.xml /epics/support/ADGenICam/db/${instance_class}.template
+                if [[ ! -s /tmp/${instance_id}-genicam.xml ]]; then
+                    # can't contact the camera - make an empty template
+                    touch /epics/support/ADGenICam/db/${instance_class}.template
+                else
+                    # make a db file from the GenICam XML
+                    python /epics/support/ADGenICam/scripts/makeDb.py /tmp/${instance_id}-genicam.xml /epics/support/ADGenICam/db/${instance_class}.template
+                fi
             fi
             # Generate pvi device from the GenICam DB
             template=/epics/support/ADGenICam/db/$instance_class.template

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -143,6 +143,7 @@ elif [ -f ${ibek_src} ]; then
                 arv-tool-0.8 -a ${instance_id} genicam > /tmp/${instance_id}-genicam.xml
                 if [[ ! -s /tmp/${instance_id}-genicam.xml ]]; then
                     # can't contact the camera - make an empty template
+                    echo "Can't connect to camera ${instance_id}"
                     touch /epics/support/ADGenICam/db/${instance_class}.template
                 else
                     # make a db file from the GenICam XML


### PR DESCRIPTION
Some minor improvements to make genicam more robust:
- for auto-gen Class of camera, make the pvi device ID 'auto-' with camera ID as the suffix
  - because the old approach created illegal device names when ID was ip address
-  cope with  arv-tool failing to connect to the camera in start.sh
- update the 'CLASS' enum in ADAravis.ibek.support.yaml to match the set of templates in the most recent ADGenicam
  - and update the pvi entry to match the new ID scheme above