### PR TITLE
Fix pvi output structure

### DIFF
--- a/ioc/scripts/makePvi.py
+++ b/ioc/scripts/makePvi.py
@@ -43,8 +43,7 @@ def get_cli_params() -> Namespace:
     Returns:
         argparse.Namespace
     """
-    usage: str = "usage: %prog [options] <input-xml> <output-folder>"
-    parser: ArgumentParser = ArgumentParser(usage=usage)
+    parser: ArgumentParser = ArgumentParser()
     parser.add_argument("input_xml", help="Input XML file")
     parser.add_argument("output_folder", help="Output folder")
     parser.add_argument("--name", dest="instance_class", required=True, help="Device class name")

--- a/ioc/scripts/makePvi.py
+++ b/ioc/scripts/makePvi.py
@@ -97,7 +97,7 @@ def convert_genicam_xml_to_pvi(xml_text: str, instance_class: str, label: str) -
     pvi_model: PviModel = PviModel(genicam_model, instance_class)
 
     # Build Device
-    device: Device = Device(label=label, parent=instance_class, children=[pvi_model.tree])
+    device: Device = Device(label=label, children=pvi_model.groups)
 
     # Return YAML from Device
     # Not using typ='safe' to default to typ='rt', ie, full round-trip YAML engine.
@@ -113,7 +113,9 @@ def convert_genicam_xml_to_pvi(xml_text: str, instance_class: str, label: str) -
     # a: {b: 1}
     ym.default_flow_style = False
     stream = StringIO()
-    ym.dump(type_first(device.model_dump(exclude_none=True)), stream)
+    data = device.model_dump(exclude_none=True)
+    data.pop("type", None)  # remove top-level type "type: Device" because pvi format doesn't like it
+    ym.dump(type_first(data), stream)
     return stream.getvalue()
 
 

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -82,7 +82,7 @@ do
             fi
         fi
         # Generate pvi device from the GenICam DB
-        python /epics/support/ADGenICam/scripts/makePvi.py /tmp/${instance_id}-genicam.xml /epics/pvi-defs/
+        python /epics/ioc/scripts/makePvi.py /tmp/${instance_id}-genicam.xml /epics/pvi-defs/
             --name $instance_class # device class
             --label "GenICam $instance_id" # instance ID
     fi

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -82,9 +82,11 @@ do
             fi
         fi
         # Generate pvi device from the GenICam DB
-        python /epics/ioc/scripts/makePvi.py /tmp/${instance_id}-genicam.xml /epics/pvi-defs/
-            --name $instance_class # device class
-            --label "GenICam $instance_id" # instance ID
+        # --name is device class
+        # --label is instance ID
+        python /epics/ioc/scripts/makePvi.py /tmp/${instance_id}-genicam.xml /epics/pvi-defs/ \
+            --name $instance_class \
+            --label "GenICam $instance_id"
     fi
 done
 

--- a/python-tests/NewInstanceClassBobCreatedWithPviFormat.bob
+++ b/python-tests/NewInstanceClassBobCreatedWithPviFormat.bob
@@ -1,0 +1,5388 @@
+<display version="2.0.0">
+  <name>NewInstance</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>2006</width>
+  <height>920</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>NewInstance</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>2006</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Acquisition</name>
+    <x>4</x>
+    <y>30</y>
+    <width>282</width>
+    <height>222</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acquisition Start</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_AcquisitionStart</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_AcquisitionStart_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acquisition Stop</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Stop acquisition. Acquisition will stop after acquisition of the current frame is complete.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_AcquisitionStop</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_AcquisitionStop = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acquisition Abort</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Abort acquisition. Acquisition will stop immediately, but a partially transferred image will be completed.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_AcquisitionAbort</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>48</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_AcquisitionAbort = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acquisition Mode</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>The acquisition mode determines the behavior of the camera when acquisition start is triggered. "Continuous" mode: the camera will acquire images until acquisition stop is triggered. "SingleFrame" mode: the camera will acquire a single image. "MultiFrame" mode: the camera will acquire the number of images specified by AcquisitionFrameCount. "Recorder" mode: the camera will run continuously, and when the recorder event is triggered, send pre-trigger and post-trigger images to the host.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_AcquisitionMode</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_AcquisitionMode_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acq Frame Count</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This is the number of images to acquire when in MultiFrame and Recorder acquisition modes.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_AcqFrameCount</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_AcqFrameCount_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acq Frame Rate Abs</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Frame rate, in frames per second. This is applicable when either the FrameStart trigger mode is disabled, or the FrameStart trigger source is FixedRate. Depending on the exposure duration, the camera may not achieve the frame rate set here.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_AcqFrameRateAbs</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_AcqFrameRateAbs_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Acq Frame Rate Limit</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This is the maximum frame rate possible for the current exposure duration and image format.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_AcqFrameRateLimit</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_AcqFrameRateLimit_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Rec Pre Event Count</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This is the number of pre-event images to acquire in the Recorder acquisition mode. This must be less than or equal to AcquisitionFrameCount.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_RecPreEventCount</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_RecPreEventCount_RBV</pv_name>
+      <x>188</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Balance White Auto Control</name>
+    <x>4</x>
+    <y>256</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Bal White Auto Rate</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Rate of white balance adjustments, from 1 (slowest) to 100 (fastest). Use this control to slow down the auto-whitebalance adjustments.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BalWhiteAutoRate</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BalWhiteAutoRate_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Bal Whi Aut Adj Tol</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Tolerance, in percent, allowed from the ideal whitebalance values, within which the auto-whitebalance does not run. This prevents needless small adjustments from occurring each image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BalWhiAutAdjTol</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BalWhiAutAdjTol_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Black Level Control</name>
+    <x>4</x>
+    <y>338</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Bla Level Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects which Black Level is controlled by the various Black Level features.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_BlaLevelSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BlaLevelSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Black Level</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Black level (offset) value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BlackLevel</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BlackLevel_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Color Transformation Control</name>
+    <x>4</x>
+    <y>420</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Col Tra Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects which Color Transformation module is controlled by the various Color Transformation features.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ColTraSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ColTraSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Col Tra Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects the mode for the color transformation.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ColTraMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ColTraMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Col Tra Val Selector</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects the Gain factor or Offset of the Transformation matrix to access in the selected Color Transformation module.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ColTraValSelector</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ColTraValSelector_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Col Tra Value</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Represents the value of the selected Gain factor or Offset inside the Transformation matrix.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ColTraValue</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ColTraValue_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Controls</name>
+    <x>4</x>
+    <y>550</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gamma</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Applies gamma value to the raw sensor signal.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Gamma</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Gamma_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Defect Mask Enable</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Enable masking of defective pixel clusters. Defective pixels are detected and recorded at the factory.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DefectMaskEnable</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DefectMaskEnable_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Hue</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Hue turns the color vectors in the U/V plane. It is 1 degree per step.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Hue</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Hue_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Saturation</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Saturation puts gain to the color vectors in the U/V plane.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Saturation</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Saturation_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>DSP Subregion</name>
+    <x>4</x>
+    <y>680</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCDSP Subregion Left</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>The DSP subregion is the area of the image used for measurements in "auto-" functions such as auto-exposure and auto-gain. DSPSubregionLeft is the left column, relative to the current image region.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionLeft</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionLeft_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCDSP Subregion Top</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>The DSP subregion is the area of the image used for measurements in "auto-" functions such as auto-exposure and auto-gain. DSPSubregionTop is the top row, relative to the current image region.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionTop</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionTop_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCDSP Subregion Right</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>The DSP subregion is the area of the image used for measurements in "auto-" functions such as auto-exposure and auto-gain. DSPSubregionRight is the right column, relative to the current image region. For convenience, this value may be higher than the maximum Width.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionRight</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DSPSubregionRight_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCDSP Sub Bottom</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>The DSP subregion is the area of the image used for measurements in "auto-" functions such as auto-exposure and auto-gain. DSPSubregionBottom is the bottom row, relative to the current image region. For convenience, this value may be higher than the maximum Height.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DSPSubBottom</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DSPSubBottom_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Defect Mask</name>
+    <x>4</x>
+    <y>810</y>
+    <width>282</width>
+    <height>54</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Def Mas Col Enable</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Enable masking of defective columns. Defective columns are detected and recorded at the factory.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_DefMasColEnable</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DefMasColEnable_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Device Status</name>
+    <x>290</x>
+    <y>30</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Dev Tem Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_DevTemSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DevTemSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device Temperature</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DeviceTemperature</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceTemperature_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Event Control</name>
+    <x>290</x>
+    <y>112</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Activate event-notification on the GigE Vision message channel.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_EventSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Notification</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Activate event-notification on the GigE Vision message channel.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_EventNotification</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventNotification_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Events Enable 1</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Activate event-notification on the GigE Vision message channel. For programmers. See register documentation.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EventsEnable1</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventsEnable1_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Event ID</name>
+    <x>290</x>
+    <y>218</y>
+    <width>282</width>
+    <height>342</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Acq Start</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveAcqStart</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveAcqStart_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Acquisition End</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveAcquisitionEnd</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveAcquisitionEnd_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Frame Trigger</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EventFrameTrigger</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventFrameTrigger_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Exposure End</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EventExposureEnd</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventExposureEnd_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Acq Rec Trigger</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveAcqRecTrigger</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveAcqRecTrigger_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Lin Rising Edge</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveLinRisingEdge</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveLinRisingEdge_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Lin Falling Edge</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveLinFallingEdge</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveLinFallingEdge_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Lin Rising Edge 0</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveLinRisingEdge0</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveLinRisingEdge0_RBV</pv_name>
+      <x>188</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Lin Falling Edg 0</text>
+      <x>0</x>
+      <y>192</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveLinFallingEdg0</pv_name>
+      <x>124</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveLinFallingEdg0_RBV</pv_name>
+      <x>188</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Fra Tri Ready</text>
+      <x>0</x>
+      <y>216</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of Frame Trigger Ready event. The Frame Trigger event occurs when the camera is ready for another frame aquisition</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveFraTriReady</pv_name>
+      <x>124</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveFraTriReady_RBV</pv_name>
+      <x>188</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Eve Exposure Start</text>
+      <x>0</x>
+      <y>240</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EveExposureStart</pv_name>
+      <x>124</x>
+      <y>240</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EveExposureStart_RBV</pv_name>
+      <x>188</x>
+      <y>240</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Overflow</text>
+      <x>0</x>
+      <y>264</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of overflow event. The overflow event occurs when one or more notification events are lost on the camera. If you use the message channel for event notification, you are always subscribed to this event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EventOverflow</pv_name>
+      <x>124</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventOverflow_RBV</pv_name>
+      <x>188</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Event Error</text>
+      <x>0</x>
+      <y>288</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ID value of error event. The error event occurs if there is a problem on the camera; this event should be reported to technical support. If you use the message channel for event notification, you are always subscribed to this event.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_EventError</pv_name>
+      <x>124</x>
+      <y>288</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_EventError_RBV</pv_name>
+      <x>188</x>
+      <y>288</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Exposure</name>
+    <x>290</x>
+    <y>564</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Auto</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Method used to set exposure duration, ExposureTimeAbs in Timed mode. Off: automatic mode is off. Once: auto-exposure occurs until target is achieved, then ExposureAuto returns to Off. Continuous: auto-exposure always runs.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ExposureAuto</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureAuto_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Method of control for exposure duration. Timed: exposure duration is set by ExposureTimeAbs. TriggerWidth: exposure controlled by external trigger pulse.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ExposureMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Time Abs</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Exposure duration in microseconds. Timed: Sensor integration time. TriggerWidth: Ignored.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExposureTimeAbs</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureTimeAbs_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exp Time Increment</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Increment of the exposure time in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExpTimeIncrement</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExpTimeIncrement_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Exposure Auto Control</name>
+    <x>290</x>
+    <y>694</y>
+    <width>282</width>
+    <height>198</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exp Auto Target</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>When ExposureAutoAlg is Mean, this is the target image mean value, in percent. Higher values result in brighter images.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExpAutoTarget</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExpAutoTarget_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Auto Alg</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Algorithm used for auto-exposure. Mean: target a particular mean value of all measured pixels in the image. FitRange: adjust the maximum pixel value to fit the sensor range.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoAlg</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoAlg_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Auto Min</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Minimum auto-exposure value, in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoMin</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoMin_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Auto Max</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum auto-exposure value, in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoMax</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoMax_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Auto Rate</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Rate of exposure adjustments, from 1 (slowest) to 100 (fastest). Use this control to slow down the auto-exposure adjustments.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoRate</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureAutoRate_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exp Auto Outliers</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Number of upper outliers to discard before calculating exposure adjustments. This is in ten-thousandths of the number pixels in the image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExpAutoOutliers</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExpAutoOutliers_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exp Auto Adjust Tol</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Tolerance, in percent, allowed from the ideal exposure value, within which the auto-exposure does not run. This prevents needless small adjustments from occurring each image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExpAutoAdjustTol</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExpAutoAdjustTol_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Gain Auto Control</name>
+    <x>576</x>
+    <y>30</y>
+    <width>282</width>
+    <height>174</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Target</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This is the target image mean value, in percent.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoTarget</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoTarget_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Min</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoMin</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoMin_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Max</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoMax</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoMax_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Rate</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Rate of gain adjustments, from 1 (slowest) to 100 (fastest). Use this control to slow down the auto-gain adjustments.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoRate</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoRate_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Outliers</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Number of upper outliers to discard before calculating gain adjustments. This is in ten-thousandths of the number pixels in the image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoOutliers</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoOutliers_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto Adjust Tol</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Tolerance, in percent, allowed from the ideal gain value, within which the auto-gain does not run. This prevents needless small adjustments from occurring each image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainAutoAdjustTol</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAutoAdjustTol_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Gain Control</name>
+    <x>576</x>
+    <y>208</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>(GenICam boilerplate. Always All.)</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_GainSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Gain value of analog A/D stage. Units are usually in dB.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Gain</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Gain_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Raw</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Gain value of analog A/D stage. Units are usually in dB.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GainRaw</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainRaw_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gain Auto</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Method used to set Gain. Off: automatic mode is off. Once: auto-gain occurs until target is achieved, then GainAuto returns to Off. Continuous: auto-gain always runs.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_GainAuto</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GainAuto_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Gig E</name>
+    <x>576</x>
+    <y>338</y>
+    <width>282</width>
+    <height>198</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Str Bytes Per Second</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_StrBytesPerSecond</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrBytesPerSecond_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Ban Control Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Bandwidth allocation can be controlled by StreamBytesPerSecond, or by register SCPD0. If you do not understand SCPD0 and how this driver uses this register, leave this set to "StreamBytesPerSecond".</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_BanControlMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BanControlMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gev SCPS Packet Size</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GevSCPSPacketSize</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GevSCPSPacketSize_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Chunk Mode Active</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ChunkModeActive</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ChunkModeActive_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Payload Size</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum size of image block payload.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_PayloadSize</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PayloadSize_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Non Ima Payload Size</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum size of chunk data, not including the image chunk, in the image block payload.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_NonImaPayloadSize</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_NonImaPayloadSize_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Str Fra Rat Con</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>When enabled, the frame rate of the camera is constrained by available bandwidth. When disabled, the camera can image faster than it can send data.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_StrFraRatCon</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrFraRatCon_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Image Format</name>
+    <x>576</x>
+    <y>540</y>
+    <width>282</width>
+    <height>246</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Width Max</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum image width for the current image mode. Horizontal binning, for example, will change this value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_WidthMax</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_WidthMax_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Height Max</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum image height for the current image mode. Vertical binning, for example, will change this value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_HeightMax</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_HeightMax_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pixel Format</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Format of the image data.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_PixelFormat</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PixelFormat_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Readout Mode</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Readout Mode of the sensor.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SensorReadoutMode</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorReadoutMode_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Width</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Width of image, in pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Width</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Width_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Height</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Height of image, in pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_Height</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_Height_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Offset X</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Starting column of the readout region (relative to the first column of the sensor) in pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_OffsetX</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_OffsetX_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Offset Y</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Starting row of the readout region (relative to the first row of the sensor) in pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_OffsetY</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_OffsetY_RBV</pv_name>
+      <x>188</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Image Size</text>
+      <x>0</x>
+      <y>192</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Size of images, in bytes, for the current format and size.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ImageSize</pv_name>
+      <x>124</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ImageSize_RBV</pv_name>
+      <x>188</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Image Mode</name>
+    <x>862</x>
+    <y>30</y>
+    <width>282</width>
+    <height>270</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Width</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Full width of image sensor.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SensorWidth</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorWidth_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Height</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Full height of image sensor.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SensorHeight</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorHeight_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Taps</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Number of taps of the camera sensor.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SensorTaps</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorTaps_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sen Dig Taps</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Number of digitized samples outputted simultaneously by the camera A/D conversion stage.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SenDigTaps</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SenDigTaps_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Binning Horizontal</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Binning in horizontal direction. Binning is the summing of charge of adjacent pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BinningHorizontal</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BinningHorizontal_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Binning Vertical</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Binning in vertical direction. Binning is the summing of charge of adjacent pixels.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BinningVertical</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BinningVertical_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Dec Horizontal</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Horizontal decimation (sub-sampling) of the image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DecHorizontal</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DecHorizontal_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Dec Vertical</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Vertical decimation (sub-sampling) of the image.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DecVertical</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DecVertical_RBV</pv_name>
+      <x>188</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Reverse X</text>
+      <x>0</x>
+      <y>192</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ReverseX is used to flip horizontally the image sent by the device. The AOI is applied after the flipping.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ReverseX</pv_name>
+      <x>124</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ReverseX_RBV</pv_name>
+      <x>188</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Reverse Y</text>
+      <x>0</x>
+      <y>216</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>ReverseY is used to flip vertically the image sent by the device. The AOI is applied after the flipping.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ReverseY</pv_name>
+      <x>124</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ReverseY_RBV</pv_name>
+      <x>188</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Info</name>
+    <x>862</x>
+    <y>304</y>
+    <width>282</width>
+    <height>318</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Firmware Ver Major</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerMajor</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerMajor_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Firmware Ver Minor</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerMinor</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerMinor_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Firmware Ver Build</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerBuild</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_FirmwareVerBuild_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Type</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Type of image sensor.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SensorType</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorType_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sensor Bits</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum bit depth of sensor.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SensorBits</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SensorBits_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device Vendor Name</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceVendorName</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device Model Name</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Camera model name.</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceModelName</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Dev Fir Version</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Firmware version of this AVT GigE camera.</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DevFirVersion</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device ID</text>
+      <x>0</x>
+      <y>192</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Serial number.</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceID</pv_name>
+      <x>124</x>
+      <y>192</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device User ID</text>
+      <x>0</x>
+      <y>216</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>User-programmable Device Identifier.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_DeviceUserID</pv_name>
+      <x>124</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceUserID_RBV</pv_name>
+      <x>188</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device Part Number</text>
+      <x>0</x>
+      <y>240</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Device part number.</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DevicePartNumber</pv_name>
+      <x>124</x>
+      <y>240</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Device Scan Type</text>
+      <x>0</x>
+      <y>264</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_DeviceScanType</pv_name>
+      <x>124</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_DeviceScanType_RBV</pv_name>
+      <x>188</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Iris</name>
+    <x>862</x>
+    <y>626</y>
+    <width>282</width>
+    <height>150</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Iris Mode</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Set the iris mode. Disabled: no iris control. Video: enable video iris. VideoOpen: fully open a video iris. VideoClose: fully close a video iris.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_IrisMode</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_IrisMode_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Iris Auto Target</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This is the target image mean value, in percent.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_IrisAutoTarget</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_IrisAutoTarget_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Iris Video Level</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Current video-iris level, in approximately mV pp; read only. When calibrating a video lens, this value should fall between IrisVideoLevelMin and IrisVideoLevelMax.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevel</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevel_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Iris Video Level Min</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Minimum video iris level output by the camera, in approximately mV pp. A higher minimum value slows the adjustment time but prevents excessive overshoot.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevelMin</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevelMin_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Iris Video Level Max</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum video iris level output by the camera, in approximately mV pp. A lower minimum value slows the adjustment time but prevents excessive overshoot.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevelMax</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_IrisVideoLevelMax_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>LUT Control</name>
+    <x>1148</x>
+    <y>30</y>
+    <width>282</width>
+    <height>198</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects which look up table is used.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_LUTSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Selects which mode is used for the selected look up table.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_LUTMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Enable</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Activates the selected LUT.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTEnable</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTEnable_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Index</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Control the index of the coefficient to access in the selected look up table.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTIndex</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTIndex_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Value</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Returns the Value at entry LUTIndex of the selected look up table</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTValue</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTValue_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Load All</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Load all look up tables from Flash.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_LUTLoadAll</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>120</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_LUTLoadAll = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Save All</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Save all look up tables in Flash.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_LUTSaveAll</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>144</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_LUTSaveAll = 1</tooltip>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>LUT Info</name>
+    <x>1148</x>
+    <y>232</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Bit Depth In</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Bit length of the input value of the look up table block</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTBitDepthIn</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTBitDepthIn_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Bit Depth Out</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Bit length of the output value of the look up table block</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTBitDepthOut</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTBitDepthOut_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Address</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Address of the memory area where the selected LUT is located (for raw memory transfer)</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTAddress</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTAddress_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GCLUT Size Bytes</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Size of the memory area where the LUT is located</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LUTSizeBytes</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LUTSizeBytes_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Lens DC Iris</name>
+    <x>1148</x>
+    <y>362</y>
+    <width>282</width>
+    <height>54</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Len DC Dri Strength</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LenDCDriStrength</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LenDCDriStrength_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Lens P Iris</name>
+    <x>1148</x>
+    <y>420</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Len P Iris Frequency</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LenPIrisFrequency</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LenPIrisFrequency_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Lens P Iris Num Steps</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LensPIrisNumSteps</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LensPIrisNumSteps_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Lens P Iris Position</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_LensPIrisPosition</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_LensPIrisPosition_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Pv Api</name>
+    <x>1148</x>
+    <y>526</y>
+    <width>282</width>
+    <height>390</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Dum Tri Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_PvDumTriSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvDumTriSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Dum Fra Sta Tri Mod</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_PvDumFraStaTriMod</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvDumFraStaTriMod_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Dum Trigger Mode</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_PvDumTriggerMode</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvDumTriggerMode_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Fra Sta Tri Delay</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_FraStaTriDelay</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_FraStaTriDelay_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Mode Value</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Method of control for exposure duration. Timed: exposure duration is set by ExposureValue. AutoOnce: auto-exposure occurs until target is achieved, then ExposureMode returns to Timed. Auto: auto-exposure always runs. TriggerWidth: exposure controlled by external trigger pulse.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_ExposureModeValue</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureModeValue_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Exposure Value</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Exposure duration, in microseconds. Timed: Sensor integration time. TriggerWidth: Ignored.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_ExposureValue</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ExposureValue_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Time Stamp Value Lo</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Low-word value of timestamp, when latched by GevTimestampControlLatch.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_TimeStampValueLo</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TimeStampValueLo_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Time Stamp Value Hi</text>
+      <x>0</x>
+      <y>168</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>High-word value of timestamp, when latched by GevTimestampControlLatch.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_TimeStampValueHi</pv_name>
+      <x>124</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TimeStampValueHi_RBV</pv_name>
+      <x>188</x>
+      <y>168</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Whitebal Value Red</text>
+      <x>0</x>
+      <y>192</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_WhitebalValueRed</pv_name>
+      <x>124</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_WhitebalValueRed_RBV</pv_name>
+      <x>188</x>
+      <y>192</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Whitebal Value Blue</text>
+      <x>0</x>
+      <y>216</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_WhitebalValueBlue</pv_name>
+      <x>124</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_WhitebalValueBlue_RBV</pv_name>
+      <x>188</x>
+      <y>216</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Model Name</text>
+      <x>0</x>
+      <y>240</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>No description provided</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_ModelName</pv_name>
+      <x>124</x>
+      <y>240</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Gain Raw</text>
+      <x>0</x>
+      <y>264</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Gain value of analog A/D stage. Units are usually in dB.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_PvGainRaw</pv_name>
+      <x>124</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvGainRaw_RBV</pv_name>
+      <x>188</x>
+      <y>264</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Gain Auto Min</text>
+      <x>0</x>
+      <y>288</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Minimum auto-gain value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_PvGainAutoMin</pv_name>
+      <x>124</x>
+      <y>288</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvGainAutoMin_RBV</pv_name>
+      <x>188</x>
+      <y>288</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Pv Gain Auto Max</text>
+      <x>0</x>
+      <y>312</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum auto-gain value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_PvGainAutoMax</pv_name>
+      <x>124</x>
+      <y>312</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_PvGainAutoMax_RBV</pv_name>
+      <x>188</x>
+      <y>312</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Offset Value</text>
+      <x>0</x>
+      <y>336</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Black level (offset) value.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_OffsetValue</pv_name>
+      <x>124</x>
+      <y>336</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_OffsetValue_RBV</pv_name>
+      <x>188</x>
+      <y>336</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Saved User Sets</name>
+    <x>1434</x>
+    <y>30</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC User Set Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Select a user set, for loading or saving camera parameters.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_UserSetSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_UserSetSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC User Set Load</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Load camera parameters from the user set specified by UserSetSelector.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_UserSetLoad</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_UserSetLoad = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC User Set Save</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Save camera parameters to the user set specified by UserSetSelector.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_UserSetSave</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>48</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_UserSetSave = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Use Set Def Selector</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>On power-up or reset, this user set is loaded.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_UseSetDefSelector</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_UseSetDefSelector_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Stream Hold</name>
+    <x>1434</x>
+    <y>160</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Stream Hold Enable</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Control on-camera image storage; this control is like a "pause" button for the image stream. When enabled, images remain stored on the camera, and are not transmitted to the host. When disabled, the image stream resumes, and any stored images are sent to the host.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_StreamHoldEnable</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StreamHoldEnable_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Str Hold Capacity</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Maximum number of images (for the current size and format) which can be stored on the camera when StreamHold is enabled.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_StrHoldCapacity</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrHoldCapacity_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Strobe</name>
+    <x>1434</x>
+    <y>242</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Strobe Source</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Signal source of the strobe timing unit. See SyncOutSource for descriptions.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_StrobeSource</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrobeSource_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Str Duration Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Mode of the strobe timing unit. Source: strobe duration is the same as source duration. Controlled: strobe duration is set by StrobeDuration.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_StrDurationMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrDurationMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Strobe Delay</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Delay from strobe trigger to strobe output, in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_StrobeDelay</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrobeDelay_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Strobe Duration</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Duration of strobe, in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_StrobeDuration</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_StrobeDuration_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Substrate Voltage</name>
+    <x>1434</x>
+    <y>372</y>
+    <width>282</width>
+    <height>54</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Vsub Value</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Substrate voltage in mV.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_VsubValue</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_VsubValue_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Sync In</name>
+    <x>1434</x>
+    <y>430</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync In Levels</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Momentary logic levels of the hardware line inputs.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SyncInLevels</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncInLevels_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync In Selector</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Select the sync-in line to control with {SyncInGlitchFilter}.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SyncInSelector</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncInSelector_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Syn In Glitch Filter</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Glitch filter on sync-in line, in nanoseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SynInGlitchFilter</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SynInGlitchFilter_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Sync Out</name>
+    <x>1434</x>
+    <y>536</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync Out Levels</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Output levels of hardware sync outputs, for output(s) in GPO mode. (Note: SyncOutPolarity can invert these values.)</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_SyncOutLevels</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncOutLevels_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync Out Selector</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Select the sync-out line to control with {SyncOutSource, SyncOutPolarity}.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SyncOutSelector</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncOutSelector_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync Out Source</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Signal source of the sync-out line specified by SyncOutSelector. GPO: general purpose output. AcquisitionTriggerReady: acquisition trigger may occur. FrameTriggerReady: frame trigger may occur. Exposing: exposure in progress. FrameReadout: image readout in progress. Imaging: exposure or frame readout in progress. Acquiring: acquisition is running. LineIn: external line input. Strobe: source is strobe timing unit.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SyncOutSource</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncOutSource_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Sync Out Polarity</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Polarity applied to the sync-out line specified by SyncOutSelector.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_SyncOutPolarity</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_SyncOutPolarity_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Timestamp</name>
+    <x>1434</x>
+    <y>666</y>
+    <width>282</width>
+    <height>126</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gev Tim Tic Fre</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Frequency of image timestamp, in Hertz.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GevTimTicFre</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GevTimTicFre_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gev Tim Con Latch</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Capture timestamp and store in GevTimestampValue.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_GevTimConLatch</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_GevTimConLatch = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gev Tim Con Reset</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Reset the timestamp.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_GevTimConReset</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>48</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_GevTimConReset = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Gev Timestamp Value</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Value of timestamp, when latched by GevTimestampControlLatch.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_GevTimestampValue</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_GevTimestampValue_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Trigger</name>
+    <x>1720</x>
+    <y>30</y>
+    <width>282</width>
+    <height>198</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Select a trigger here, then use the controls {TriggerMode, TriggerSoftware, TriggerSource, TriggerActivation, TriggerOverlap, TriggerDelayAbs} to setup and read the trigger attributes. FrameStart is the trigger which starts each image (when acquisition is running). AcquisitionStart is the trigger which starts the acquisition process.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_TriggerSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Mode</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Enable or disable this trigger. Note: when the FrameStart trigger is disabled, images are triggered at a fixed rate specified by AcquisitionFrameRateAbs.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_TriggerMode</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerMode_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Software</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>This software command effects a trigger.</tooltip>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>WritePV</name>
+      <pv_name>$(P)$(R)GC_TriggerSoftware</pv_name>
+      <actions>
+        <action type="write_pv">
+          <pv_name>$(pv_name)</pv_name>
+          <value>1</value>
+          <description>$(name)</description>
+        </action>
+      </actions>
+      <text>Go</text>
+      <x>124</x>
+      <y>48</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(P)$(R)GC_TriggerSoftware = 1</tooltip>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Source</text>
+      <x>0</x>
+      <y>72</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Source of trigger, when TriggerMode is On. This might be an hardware trigger, a fixed rate generator, or software trigger only.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_TriggerSource</pv_name>
+      <x>124</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerSource_RBV</pv_name>
+      <x>188</x>
+      <y>72</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Activation</text>
+      <x>0</x>
+      <y>96</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Type of activation, for hardware triggers. This controls edge/level and polarity sensitivities.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_TriggerActivation</pv_name>
+      <x>124</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerActivation_RBV</pv_name>
+      <x>188</x>
+      <y>96</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Overlap</text>
+      <x>0</x>
+      <y>120</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Permitted window of trigger activation, relative to previous frame.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_TriggerOverlap</pv_name>
+      <x>124</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerOverlap_RBV</pv_name>
+      <x>188</x>
+      <y>120</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Trigger Delay Abs</text>
+      <x>0</x>
+      <y>144</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Delay from hardware trigger activation to trigger effect, in microseconds.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_TriggerDelayAbs</pv_name>
+      <x>124</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_TriggerDelayAbs_RBV</pv_name>
+      <x>188</x>
+      <y>144</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Whitebalance</name>
+    <x>1720</x>
+    <y>232</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Bal Ratio Selector</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Select the Red or Blue channel to adjust with BalanceRatioAbs.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_BalRatioSelector</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BalRatioSelector_RBV</pv_name>
+      <x>188</x>
+      <y>0</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Balance Ratio Abs</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Adjust the gain of the red or blue channel (see BalanceRatioSelector). The green channel gain is always 1.00.</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>$(P)$(R)GC_BalanceRatioAbs</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BalanceRatioAbs_RBV</pv_name>
+      <x>188</x>
+      <y>24</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>GC Balance White Auto</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Method used to set White Balance values. Off: automatic mode is off. Once: auto-whitebalance occurs until target is achieved, then BalanceWhiteAuto returns to Off. Continuous: auto-whitebalance always runs.</tooltip>
+    </widget>
+    <widget type="combo" version="2.0.0">
+      <name>ComboBox</name>
+      <pv_name>$(P)$(R)GC_BalanceWhiteAuto</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GC_BalanceWhiteAuto_RBV</pv_name>
+      <x>188</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+</display>

--- a/python-tests/NewInstanceClassPVIYamlCreatedWithMakePvi.pvi.device.yaml
+++ b/python-tests/NewInstanceClassPVIYamlCreatedWithMakePvi.pvi.device.yaml
@@ -1,1822 +1,1801 @@
-type: Device
 label: NewInstance
-parent: NewInstanceClassPVIYamlCreatedWithMakePvi
 children:
 - type: Group
-  name: NewInstanceClassPVIYamlCreatedWithMakePvi
+  name: Acquisition
   layout:
     type: Grid
     labelled: true
   children:
-  - type: Group
-    name: Acquisition
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCAcquisitionStart
-      write_pv: $(P)$(R)GC_AcquisitionStart
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_AcquisitionStart_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalX
-      name: GCAcquisitionStop
-      description: Stop acquisition. Acquisition will stop after acquisition of 
-        the current frame is complete.
-      write_pv: $(P)$(R)GC_AcquisitionStop
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalX
-      name: GCAcquisitionAbort
-      description: Abort acquisition. Acquisition will stop immediately, but a 
-        partially transferred image will be completed.
-      write_pv: $(P)$(R)GC_AcquisitionAbort
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalRW
-      name: GCAcquisitionMode
-      description: 'The acquisition mode determines the behavior of the camera when
-        acquisition start is triggered. "Continuous" mode: the camera will acquire
-        images until acquisition stop is triggered. "SingleFrame" mode: the camera
-        will acquire a single image. "MultiFrame" mode: the camera will acquire the
-        number of images specified by AcquisitionFrameCount. "Recorder" mode: the
-        camera will run continuously, and when the recorder event is triggered, send
-        pre-trigger and post-trigger images to the host.'
-      write_pv: $(P)$(R)GC_AcquisitionMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_AcquisitionMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCAcqFrameCount
-      description: This is the number of images to acquire when in MultiFrame 
-        and Recorder acquisition modes.
-      write_pv: $(P)$(R)GC_AcqFrameCount
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_AcqFrameCount_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCAcqFrameRateAbs
-      description: Frame rate, in frames per second. This is applicable when 
-        either the FrameStart trigger mode is disabled, or the FrameStart 
-        trigger source is FixedRate. Depending on the exposure duration, the 
-        camera may not achieve the frame rate set here.
-      write_pv: $(P)$(R)GC_AcqFrameRateAbs
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_AcqFrameRateAbs_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCAcqFrameRateLimit
-      description: This is the maximum frame rate possible for the current 
-        exposure duration and image format.
-      write_pv: $(P)$(R)GC_AcqFrameRateLimit
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_AcqFrameRateLimit_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCRecPreEventCount
-      description: This is the number of pre-event images to acquire in the 
-        Recorder acquisition mode. This must be less than or equal to 
-        AcquisitionFrameCount.
-      write_pv: $(P)$(R)GC_RecPreEventCount
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_RecPreEventCount_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: BalanceWhiteAutoControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCBalWhiteAutoRate
-      description: Rate of white balance adjustments, from 1 (slowest) to 100 
-        (fastest). Use this control to slow down the auto-whitebalance 
-        adjustments.
-      write_pv: $(P)$(R)GC_BalWhiteAutoRate
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BalWhiteAutoRate_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBalWhiAutAdjTol
-      description: Tolerance, in percent, allowed from the ideal whitebalance 
-        values, within which the auto-whitebalance does not run. This prevents 
-        needless small adjustments from occurring each image.
-      write_pv: $(P)$(R)GC_BalWhiAutAdjTol
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BalWhiAutAdjTol_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: BlackLevelControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCBlaLevelSelector
-      description: Selects which Black Level is controlled by the various Black 
-        Level features.
-      write_pv: $(P)$(R)GC_BlaLevelSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_BlaLevelSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBlackLevel
-      description: Black level (offset) value.
-      write_pv: $(P)$(R)GC_BlackLevel
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BlackLevel_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: ColorTransformationControl
-    description: Category that contains the Color Transformation control 
-      features.
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCColTraSelector
-      description: Selects which Color Transformation module is controlled by 
-        the various Color Transformation features.
-      write_pv: $(P)$(R)GC_ColTraSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ColTraSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCColTraMode
-      description: Selects the mode for the color transformation.
-      write_pv: $(P)$(R)GC_ColTraMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ColTraMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCColTraValSelector
-      description: Selects the Gain factor or Offset of the Transformation 
-        matrix to access in the selected Color Transformation module.
-      write_pv: $(P)$(R)GC_ColTraValSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ColTraValSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCColTraValue
-      description: Represents the value of the selected Gain factor or Offset 
-        inside the Transformation matrix.
-      write_pv: $(P)$(R)GC_ColTraValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ColTraValue_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Controls
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCGamma
-      description: Applies gamma value to the raw sensor signal.
-      write_pv: $(P)$(R)GC_Gamma
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Gamma_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDefectMaskEnable
-      description: Enable masking of defective pixel clusters. Defective pixels 
-        are detected and recorded at the factory.
-      write_pv: $(P)$(R)GC_DefectMaskEnable
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DefectMaskEnable_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCHue
-      description: Hue turns the color vectors in the U/V plane. It is 1 degree 
-        per step.
-      write_pv: $(P)$(R)GC_Hue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Hue_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSaturation
-      description: Saturation puts gain to the color vectors in the U/V plane.
-      write_pv: $(P)$(R)GC_Saturation
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Saturation_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: DSPSubregion
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCDSPSubregionLeft
-      description: The DSP subregion is the area of the image used for 
-        measurements in "auto-" functions such as auto-exposure and auto-gain. 
-        DSPSubregionLeft is the left column, relative to the current image 
-        region.
-      write_pv: $(P)$(R)GC_DSPSubregionLeft
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DSPSubregionLeft_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDSPSubregionTop
-      description: The DSP subregion is the area of the image used for 
-        measurements in "auto-" functions such as auto-exposure and auto-gain. 
-        DSPSubregionTop is the top row, relative to the current image region.
-      write_pv: $(P)$(R)GC_DSPSubregionTop
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DSPSubregionTop_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDSPSubregionRight
-      description: The DSP subregion is the area of the image used for 
-        measurements in "auto-" functions such as auto-exposure and auto-gain. 
-        DSPSubregionRight is the right column, relative to the current image 
-        region. For convenience, this value may be higher than the maximum 
-        Width.
-      write_pv: $(P)$(R)GC_DSPSubregionRight
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DSPSubregionRight_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDSPSubBottom
-      description: The DSP subregion is the area of the image used for 
-        measurements in "auto-" functions such as auto-exposure and auto-gain. 
-        DSPSubregionBottom is the bottom row, relative to the current image 
-        region. For convenience, this value may be higher than the maximum 
-        Height.
-      write_pv: $(P)$(R)GC_DSPSubBottom
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DSPSubBottom_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: DefectMask
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCDefMasColEnable
-      description: Enable masking of defective columns. Defective columns are 
-        detected and recorded at the factory.
-      write_pv: $(P)$(R)GC_DefMasColEnable
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_DefMasColEnable_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: DeviceStatus
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCDevTemSelector
-      write_pv: $(P)$(R)GC_DevTemSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_DevTemSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDeviceTemperature
-      write_pv: $(P)$(R)GC_DeviceTemperature
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DeviceTemperature_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: EventControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCEventSelector
-      description: Activate event-notification on the GigE Vision message 
-        channel.
-      write_pv: $(P)$(R)GC_EventSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_EventSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventNotification
-      description: Activate event-notification on the GigE Vision message 
-        channel.
-      write_pv: $(P)$(R)GC_EventNotification
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_EventNotification_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventsEnable1
-      description: Activate event-notification on the GigE Vision message 
-        channel. For programmers. See register documentation.
-      write_pv: $(P)$(R)GC_EventsEnable1
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EventsEnable1_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: EventID
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCEveAcqStart
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveAcqStart
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveAcqStart_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveAcquisitionEnd
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveAcquisitionEnd
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveAcquisitionEnd_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventFrameTrigger
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EventFrameTrigger
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EventFrameTrigger_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventExposureEnd
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EventExposureEnd
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EventExposureEnd_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveAcqRecTrigger
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveAcqRecTrigger
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveAcqRecTrigger_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveLinRisingEdge
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveLinRisingEdge
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveLinRisingEdge_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveLinFallingEdge
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveLinFallingEdge
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveLinFallingEdge_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveLinRisingEdge0
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveLinRisingEdge0
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveLinRisingEdge0_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveLinFallingEdg0
-      description: ID value of event.
-      write_pv: $(P)$(R)GC_EveLinFallingEdg0
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveLinFallingEdg0_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveFraTriReady
-      description: ID value of Frame Trigger Ready event. The Frame Trigger 
-        event occurs when the camera is ready for another frame aquisition
-      write_pv: $(P)$(R)GC_EveFraTriReady
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveFraTriReady_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEveExposureStart
-      write_pv: $(P)$(R)GC_EveExposureStart
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EveExposureStart_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventOverflow
-      description: ID value of overflow event. The overflow event occurs when 
-        one or more notification events are lost on the camera. If you use the 
-        message channel for event notification, you are always subscribed to 
-        this event.
-      write_pv: $(P)$(R)GC_EventOverflow
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EventOverflow_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCEventError
-      description: ID value of error event. The error event occurs if there is a
-        problem on the camera; this event should be reported to technical 
-        support. If you use the message channel for event notification, you are 
-        always subscribed to this event.
-      write_pv: $(P)$(R)GC_EventError
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_EventError_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Exposure
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCExposureAuto
-      description: 'Method used to set exposure duration, ExposureTimeAbs in Timed
-        mode. Off: automatic mode is off. Once: auto-exposure occurs until target
-        is achieved, then ExposureAuto returns to Off. Continuous: auto-exposure always
-        runs.'
-      write_pv: $(P)$(R)GC_ExposureAuto
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ExposureAuto_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureMode
-      description: 'Method of control for exposure duration. Timed: exposure duration
-        is set by ExposureTimeAbs. TriggerWidth: exposure controlled by external trigger
-        pulse.'
-      write_pv: $(P)$(R)GC_ExposureMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ExposureMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureTimeAbs
-      description: 'Exposure duration in microseconds. Timed: Sensor integration time.
-        TriggerWidth: Ignored.'
-      write_pv: $(P)$(R)GC_ExposureTimeAbs
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExposureTimeAbs_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExpTimeIncrement
-      description: Increment of the exposure time in microseconds.
-      write_pv: $(P)$(R)GC_ExpTimeIncrement
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExpTimeIncrement_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: ExposureAutoControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCExpAutoTarget
-      description: When ExposureAutoAlg is Mean, this is the target image mean 
-        value, in percent. Higher values result in brighter images.
-      write_pv: $(P)$(R)GC_ExpAutoTarget
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExpAutoTarget_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureAutoAlg
-      description: 'Algorithm used for auto-exposure. Mean: target a particular mean
-        value of all measured pixels in the image. FitRange: adjust the maximum pixel
-        value to fit the sensor range.'
-      write_pv: $(P)$(R)GC_ExposureAutoAlg
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ExposureAutoAlg_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureAutoMin
-      description: Minimum auto-exposure value, in microseconds.
-      write_pv: $(P)$(R)GC_ExposureAutoMin
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExposureAutoMin_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureAutoMax
-      description: Maximum auto-exposure value, in microseconds.
-      write_pv: $(P)$(R)GC_ExposureAutoMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExposureAutoMax_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureAutoRate
-      description: Rate of exposure adjustments, from 1 (slowest) to 100 
-        (fastest). Use this control to slow down the auto-exposure adjustments.
-      write_pv: $(P)$(R)GC_ExposureAutoRate
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExposureAutoRate_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExpAutoOutliers
-      description: Number of upper outliers to discard before calculating 
-        exposure adjustments. This is in ten-thousandths of the number pixels in
-        the image.
-      write_pv: $(P)$(R)GC_ExpAutoOutliers
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExpAutoOutliers_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExpAutoAdjustTol
-      description: Tolerance, in percent, allowed from the ideal exposure value,
-        within which the auto-exposure does not run. This prevents needless 
-        small adjustments from occurring each image.
-      write_pv: $(P)$(R)GC_ExpAutoAdjustTol
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExpAutoAdjustTol_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: GainAutoControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCGainAutoTarget
-      description: This is the target image mean value, in percent.
-      write_pv: $(P)$(R)GC_GainAutoTarget
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoTarget_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAutoMin
-      write_pv: $(P)$(R)GC_GainAutoMin
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoMin_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAutoMax
-      write_pv: $(P)$(R)GC_GainAutoMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoMax_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAutoRate
-      description: Rate of gain adjustments, from 1 (slowest) to 100 (fastest). 
-        Use this control to slow down the auto-gain adjustments.
-      write_pv: $(P)$(R)GC_GainAutoRate
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoRate_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAutoOutliers
-      description: Number of upper outliers to discard before calculating gain 
-        adjustments. This is in ten-thousandths of the number pixels in the 
-        image.
-      write_pv: $(P)$(R)GC_GainAutoOutliers
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoOutliers_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAutoAdjustTol
-      description: Tolerance, in percent, allowed from the ideal gain value, 
-        within which the auto-gain does not run. This prevents needless small 
-        adjustments from occurring each image.
-      write_pv: $(P)$(R)GC_GainAutoAdjustTol
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainAutoAdjustTol_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: GainControl
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCGainSelector
-      description: (GenICam boilerplate. Always All.)
-      write_pv: $(P)$(R)GC_GainSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_GainSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGain
-      description: Gain value of analog A/D stage. Units are usually in dB.
-      write_pv: $(P)$(R)GC_Gain
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Gain_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainRaw
-      description: Gain value of analog A/D stage. Units are usually in dB.
-      write_pv: $(P)$(R)GC_GainRaw
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GainRaw_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGainAuto
-      description: 'Method used to set Gain. Off: automatic mode is off. Once: auto-gain
-        occurs until target is achieved, then GainAuto returns to Off. Continuous:
-        auto-gain always runs.'
-      write_pv: $(P)$(R)GC_GainAuto
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_GainAuto_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: GigE
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCStrBytesPerSecond
-      write_pv: $(P)$(R)GC_StrBytesPerSecond
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_StrBytesPerSecond_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBanControlMode
-      description: Bandwidth allocation can be controlled by 
-        StreamBytesPerSecond, or by register SCPD0. If you do not understand 
-        SCPD0 and how this driver uses this register, leave this set to 
-        "StreamBytesPerSecond".
-      write_pv: $(P)$(R)GC_BanControlMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_BanControlMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCGevSCPSPacketSize
-      write_pv: $(P)$(R)GC_GevSCPSPacketSize
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GevSCPSPacketSize_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCChunkModeActive
-      write_pv: $(P)$(R)GC_ChunkModeActive
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ChunkModeActive_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPayloadSize
-      description: Maximum size of image block payload.
-      write_pv: $(P)$(R)GC_PayloadSize
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_PayloadSize_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCNonImaPayloadSize
-      description: Maximum size of chunk data, not including the image chunk, in
-        the image block payload.
-      write_pv: $(P)$(R)GC_NonImaPayloadSize
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_NonImaPayloadSize_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCStrFraRatCon
-      description: When enabled, the frame rate of the camera is constrained by 
-        available bandwidth. When disabled, the camera can image faster than it 
-        can send data.
-      write_pv: $(P)$(R)GC_StrFraRatCon
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_StrFraRatCon_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: ImageFormat
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCWidthMax
-      description: Maximum image width for the current image mode. Horizontal 
-        binning, for example, will change this value.
-      write_pv: $(P)$(R)GC_WidthMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_WidthMax_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCHeightMax
-      description: Maximum image height for the current image mode. Vertical 
-        binning, for example, will change this value.
-      write_pv: $(P)$(R)GC_HeightMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_HeightMax_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPixelFormat
-      description: Format of the image data.
-      write_pv: $(P)$(R)GC_PixelFormat
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_PixelFormat_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSensorReadoutMode
-      description: Readout Mode of the sensor.
-      write_pv: $(P)$(R)GC_SensorReadoutMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SensorReadoutMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCWidth
-      description: Width of image, in pixels.
-      write_pv: $(P)$(R)GC_Width
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Width_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCHeight
-      description: Height of image, in pixels.
-      write_pv: $(P)$(R)GC_Height
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_Height_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCOffsetX
-      description: Starting column of the readout region (relative to the first 
-        column of the sensor) in pixels.
-      write_pv: $(P)$(R)GC_OffsetX
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_OffsetX_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCOffsetY
-      description: Starting row of the readout region (relative to the first row
-        of the sensor) in pixels.
-      write_pv: $(P)$(R)GC_OffsetY
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_OffsetY_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCImageSize
-      description: Size of images, in bytes, for the current format and size.
-      write_pv: $(P)$(R)GC_ImageSize
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ImageSize_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: ImageMode
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCSensorWidth
-      description: Full width of image sensor.
-      write_pv: $(P)$(R)GC_SensorWidth
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SensorWidth_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSensorHeight
-      description: Full height of image sensor.
-      write_pv: $(P)$(R)GC_SensorHeight
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SensorHeight_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSensorTaps
-      description: Number of taps of the camera sensor.
-      write_pv: $(P)$(R)GC_SensorTaps
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SensorTaps_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSenDigTaps
-      description: Number of digitized samples outputted simultaneously by the 
-        camera A/D conversion stage.
-      write_pv: $(P)$(R)GC_SenDigTaps
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SenDigTaps_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBinningHorizontal
-      description: Binning in horizontal direction. Binning is the summing of 
-        charge of adjacent pixels.
-      write_pv: $(P)$(R)GC_BinningHorizontal
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BinningHorizontal_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBinningVertical
-      description: Binning in vertical direction. Binning is the summing of 
-        charge of adjacent pixels.
-      write_pv: $(P)$(R)GC_BinningVertical
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BinningVertical_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDecHorizontal
-      description: Horizontal decimation (sub-sampling) of the image.
-      write_pv: $(P)$(R)GC_DecHorizontal
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DecHorizontal_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDecVertical
-      description: Vertical decimation (sub-sampling) of the image.
-      write_pv: $(P)$(R)GC_DecVertical
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DecVertical_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCReverseX
-      description: ReverseX is used to flip horizontally the image sent by the 
-        device. The AOI is applied after the flipping.
-      write_pv: $(P)$(R)GC_ReverseX
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ReverseX_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCReverseY
-      description: ReverseY is used to flip vertically the image sent by the 
-        device. The AOI is applied after the flipping.
-      write_pv: $(P)$(R)GC_ReverseY
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ReverseY_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Info
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCFirmwareVerMajor
-      write_pv: $(P)$(R)GC_FirmwareVerMajor
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_FirmwareVerMajor_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCFirmwareVerMinor
-      write_pv: $(P)$(R)GC_FirmwareVerMinor
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_FirmwareVerMinor_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCFirmwareVerBuild
-      write_pv: $(P)$(R)GC_FirmwareVerBuild
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_FirmwareVerBuild_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSensorType
-      description: Type of image sensor.
-      write_pv: $(P)$(R)GC_SensorType
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SensorType_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSensorBits
-      description: Maximum bit depth of sensor.
-      write_pv: $(P)$(R)GC_SensorBits
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SensorBits_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCDeviceVendorName
-      read_pv: $(P)$(R)GC_DeviceVendorName
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCDeviceModelName
-      description: Camera model name.
-      read_pv: $(P)$(R)GC_DeviceModelName
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCDevFirVersion
-      description: Firmware version of this AVT GigE camera.
-      read_pv: $(P)$(R)GC_DevFirVersion
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCDeviceID
-      description: Serial number.
-      read_pv: $(P)$(R)GC_DeviceID
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDeviceUserID
-      description: User-programmable Device Identifier.
-      write_pv: $(P)$(R)GC_DeviceUserID
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_DeviceUserID_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCDevicePartNumber
-      description: Device part number.
-      read_pv: $(P)$(R)GC_DevicePartNumber
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCDeviceScanType
-      write_pv: $(P)$(R)GC_DeviceScanType
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_DeviceScanType_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Iris
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCIrisMode
-      description: 'Set the iris mode. Disabled: no iris control. Video: enable video
-        iris. VideoOpen: fully open a video iris. VideoClose: fully close a video
-        iris.'
-      write_pv: $(P)$(R)GC_IrisMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_IrisMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCIrisAutoTarget
-      description: This is the target image mean value, in percent.
-      write_pv: $(P)$(R)GC_IrisAutoTarget
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_IrisAutoTarget_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCIrisVideoLevel
-      description: Current video-iris level, in approximately mV pp; read only. 
-        When calibrating a video lens, this value should fall between 
-        IrisVideoLevelMin and IrisVideoLevelMax.
-      write_pv: $(P)$(R)GC_IrisVideoLevel
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_IrisVideoLevel_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCIrisVideoLevelMin
-      description: Minimum video iris level output by the camera, in 
-        approximately mV pp. A higher minimum value slows the adjustment time 
-        but prevents excessive overshoot.
-      write_pv: $(P)$(R)GC_IrisVideoLevelMin
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_IrisVideoLevelMin_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCIrisVideoLevelMax
-      description: Maximum video iris level output by the camera, in 
-        approximately mV pp. A lower minimum value slows the adjustment time but
-        prevents excessive overshoot.
-      write_pv: $(P)$(R)GC_IrisVideoLevelMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_IrisVideoLevelMax_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: LUTControl
-    description: Category that includes the LUT control features.
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCLUTSelector
-      description: Selects which look up table is used.
-      write_pv: $(P)$(R)GC_LUTSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_LUTSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTMode
-      description: Selects which mode is used for the selected look up table.
-      write_pv: $(P)$(R)GC_LUTMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_LUTMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTEnable
-      description: Activates the selected LUT.
-      write_pv: $(P)$(R)GC_LUTEnable
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTEnable_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTIndex
-      description: Control the index of the coefficient to access in the 
-        selected look up table.
-      write_pv: $(P)$(R)GC_LUTIndex
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTIndex_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTValue
-      description: Returns the Value at entry LUTIndex of the selected look up 
-        table
-      write_pv: $(P)$(R)GC_LUTValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTValue_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalX
-      name: GCLUTLoadAll
-      description: Load all look up tables from Flash.
-      write_pv: $(P)$(R)GC_LUTLoadAll
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalX
-      name: GCLUTSaveAll
-      description: Save all look up tables in Flash.
-      write_pv: $(P)$(R)GC_LUTSaveAll
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-  - type: Group
-    name: LUTInfo
-    description: Category that includes the LUT info features for the look up 
-      table.
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCLUTBitDepthIn
-      description: Bit length of the input value of the look up table block
-      write_pv: $(P)$(R)GC_LUTBitDepthIn
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTBitDepthIn_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTBitDepthOut
-      description: Bit length of the output value of the look up table block
-      write_pv: $(P)$(R)GC_LUTBitDepthOut
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTBitDepthOut_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTAddress
-      description: Address of the memory area where the selected LUT is located 
-        (for raw memory transfer)
-      write_pv: $(P)$(R)GC_LUTAddress
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTAddress_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLUTSizeBytes
-      description: Size of the memory area where the LUT is located
-      write_pv: $(P)$(R)GC_LUTSizeBytes
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LUTSizeBytes_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: LensDCIris
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCLenDCDriStrength
-      write_pv: $(P)$(R)GC_LenDCDriStrength
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LenDCDriStrength_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: LensPIris
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCLenPIrisFrequency
-      write_pv: $(P)$(R)GC_LenPIrisFrequency
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LenPIrisFrequency_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLensPIrisNumSteps
-      write_pv: $(P)$(R)GC_LensPIrisNumSteps
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LensPIrisNumSteps_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCLensPIrisPosition
-      write_pv: $(P)$(R)GC_LensPIrisPosition
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_LensPIrisPosition_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: PvApi
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCPvDumTriSelector
-      write_pv: $(P)$(R)GC_PvDumTriSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_PvDumTriSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPvDumFraStaTriMod
-      write_pv: $(P)$(R)GC_PvDumFraStaTriMod
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_PvDumFraStaTriMod_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPvDumTriggerMode
-      write_pv: $(P)$(R)GC_PvDumTriggerMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_PvDumTriggerMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCFraStaTriDelay
-      write_pv: $(P)$(R)GC_FraStaTriDelay
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_FraStaTriDelay_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureModeValue
-      description: 'Method of control for exposure duration. Timed: exposure duration
-        is set by ExposureValue. AutoOnce: auto-exposure occurs until target is achieved,
-        then ExposureMode returns to Timed. Auto: auto-exposure always runs. TriggerWidth:
-        exposure controlled by external trigger pulse.'
-      write_pv: $(P)$(R)GC_ExposureModeValue
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_ExposureModeValue_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCExposureValue
-      description: 'Exposure duration, in microseconds. Timed: Sensor integration
-        time. TriggerWidth: Ignored.'
-      write_pv: $(P)$(R)GC_ExposureValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_ExposureValue_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTimeStampValueLo
-      description: Low-word value of timestamp, when latched by 
-        GevTimestampControlLatch.
-      write_pv: $(P)$(R)GC_TimeStampValueLo
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_TimeStampValueLo_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTimeStampValueHi
-      description: High-word value of timestamp, when latched by 
-        GevTimestampControlLatch.
-      write_pv: $(P)$(R)GC_TimeStampValueHi
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_TimeStampValueHi_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCWhitebalValueRed
-      write_pv: $(P)$(R)GC_WhitebalValueRed
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_WhitebalValueRed_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCWhitebalValueBlue
-      write_pv: $(P)$(R)GC_WhitebalValueBlue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_WhitebalValueBlue_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalR
-      name: GCModelName
-      read_pv: $(P)$(R)GC_ModelName
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPvGainRaw
-      description: Gain value of analog A/D stage. Units are usually in dB.
-      write_pv: $(P)$(R)GC_PvGainRaw
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_PvGainRaw_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPvGainAutoMin
-      description: Minimum auto-gain value.
-      write_pv: $(P)$(R)GC_PvGainAutoMin
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_PvGainAutoMin_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCPvGainAutoMax
-      description: Maximum auto-gain value.
-      write_pv: $(P)$(R)GC_PvGainAutoMax
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_PvGainAutoMax_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCOffsetValue
-      description: Black level (offset) value.
-      write_pv: $(P)$(R)GC_OffsetValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_OffsetValue_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: SavedUserSets
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCUserSetSelector
-      description: Select a user set, for loading or saving camera parameters.
-      write_pv: $(P)$(R)GC_UserSetSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_UserSetSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalX
-      name: GCUserSetLoad
-      description: Load camera parameters from the user set specified by 
-        UserSetSelector.
-      write_pv: $(P)$(R)GC_UserSetLoad
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalX
-      name: GCUserSetSave
-      description: Save camera parameters to the user set specified by 
-        UserSetSelector.
-      write_pv: $(P)$(R)GC_UserSetSave
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalRW
-      name: GCUseSetDefSelector
-      description: On power-up or reset, this user set is loaded.
-      write_pv: $(P)$(R)GC_UseSetDefSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_UseSetDefSelector_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: StreamHold
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCStreamHoldEnable
-      description: Control on-camera image storage; this control is like a 
-        "pause" button for the image stream. When enabled, images remain stored 
-        on the camera, and are not transmitted to the host. When disabled, the 
-        image stream resumes, and any stored images are sent to the host.
-      write_pv: $(P)$(R)GC_StreamHoldEnable
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_StreamHoldEnable_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCStrHoldCapacity
-      description: Maximum number of images (for the current size and format) 
-        which can be stored on the camera when StreamHold is enabled.
-      write_pv: $(P)$(R)GC_StrHoldCapacity
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_StrHoldCapacity_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Strobe
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCStrobeSource
-      description: Signal source of the strobe timing unit. See SyncOutSource 
-        for descriptions.
-      write_pv: $(P)$(R)GC_StrobeSource
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_StrobeSource_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCStrDurationMode
-      description: 'Mode of the strobe timing unit. Source: strobe duration is the
-        same as source duration. Controlled: strobe duration is set by StrobeDuration.'
-      write_pv: $(P)$(R)GC_StrDurationMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_StrDurationMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCStrobeDelay
-      description: Delay from strobe trigger to strobe output, in microseconds.
-      write_pv: $(P)$(R)GC_StrobeDelay
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_StrobeDelay_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCStrobeDuration
-      description: Duration of strobe, in microseconds.
-      write_pv: $(P)$(R)GC_StrobeDuration
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_StrobeDuration_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: SubstrateVoltage
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCVsubValue
-      description: Substrate voltage in mV.
-      write_pv: $(P)$(R)GC_VsubValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_VsubValue_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: SyncIn
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCSyncInLevels
-      description: Momentary logic levels of the hardware line inputs.
-      write_pv: $(P)$(R)GC_SyncInLevels
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SyncInLevels_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSyncInSelector
-      description: Select the sync-in line to control with {SyncInGlitchFilter}.
-      write_pv: $(P)$(R)GC_SyncInSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SyncInSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSynInGlitchFilter
-      description: Glitch filter on sync-in line, in nanoseconds.
-      write_pv: $(P)$(R)GC_SynInGlitchFilter
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SynInGlitchFilter_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: SyncOut
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCSyncOutLevels
-      description: 'Output levels of hardware sync outputs, for output(s) in GPO mode.
-        (Note: SyncOutPolarity can invert these values.)'
-      write_pv: $(P)$(R)GC_SyncOutLevels
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_SyncOutLevels_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSyncOutSelector
-      description: Select the sync-out line to control with {SyncOutSource, 
-        SyncOutPolarity}.
-      write_pv: $(P)$(R)GC_SyncOutSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SyncOutSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSyncOutSource
-      description: 'Signal source of the sync-out line specified by SyncOutSelector.
-        GPO: general purpose output. AcquisitionTriggerReady: acquisition trigger
-        may occur. FrameTriggerReady: frame trigger may occur. Exposing: exposure
-        in progress. FrameReadout: image readout in progress. Imaging: exposure or
-        frame readout in progress. Acquiring: acquisition is running. LineIn: external
-        line input. Strobe: source is strobe timing unit.'
-      write_pv: $(P)$(R)GC_SyncOutSource
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SyncOutSource_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCSyncOutPolarity
-      description: Polarity applied to the sync-out line specified by 
-        SyncOutSelector.
-      write_pv: $(P)$(R)GC_SyncOutPolarity
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_SyncOutPolarity_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Timestamp
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCGevTimTicFre
-      description: Frequency of image timestamp, in Hertz.
-      write_pv: $(P)$(R)GC_GevTimTicFre
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GevTimTicFre_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalX
-      name: GCGevTimConLatch
-      description: Capture timestamp and store in GevTimestampValue.
-      write_pv: $(P)$(R)GC_GevTimConLatch
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalX
-      name: GCGevTimConReset
-      description: Reset the timestamp.
-      write_pv: $(P)$(R)GC_GevTimConReset
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalRW
-      name: GCGevTimestampValue
-      description: Value of timestamp, when latched by GevTimestampControlLatch.
-      write_pv: $(P)$(R)GC_GevTimestampValue
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_GevTimestampValue_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Trigger
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCTriggerSelector
-      description: Select a trigger here, then use the controls {TriggerMode, 
-        TriggerSoftware, TriggerSource, TriggerActivation, TriggerOverlap, 
-        TriggerDelayAbs} to setup and read the trigger attributes. FrameStart is
-        the trigger which starts each image (when acquisition is running). 
-        AcquisitionStart is the trigger which starts the acquisition process.
-      write_pv: $(P)$(R)GC_TriggerSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_TriggerSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTriggerMode
-      description: 'Enable or disable this trigger. Note: when the FrameStart trigger
-        is disabled, images are triggered at a fixed rate specified by AcquisitionFrameRateAbs.'
-      write_pv: $(P)$(R)GC_TriggerMode
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_TriggerMode_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalX
-      name: GCTriggerSoftware
-      description: This software command effects a trigger.
-      write_pv: $(P)$(R)GC_TriggerSoftware
-      write_widget:
-        type: ButtonPanel
-        actions:
-          Go: '1'
-      value: '1'
-    - type: SignalRW
-      name: GCTriggerSource
-      description: Source of trigger, when TriggerMode is On. This might be an 
-        hardware trigger, a fixed rate generator, or software trigger only.
-      write_pv: $(P)$(R)GC_TriggerSource
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_TriggerSource_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTriggerActivation
-      description: Type of activation, for hardware triggers. This controls 
-        edge/level and polarity sensitivities.
-      write_pv: $(P)$(R)GC_TriggerActivation
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_TriggerActivation_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTriggerOverlap
-      description: Permitted window of trigger activation, relative to previous 
-        frame.
-      write_pv: $(P)$(R)GC_TriggerOverlap
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_TriggerOverlap_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCTriggerDelayAbs
-      description: Delay from hardware trigger activation to trigger effect, in 
-        microseconds.
-      write_pv: $(P)$(R)GC_TriggerDelayAbs
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_TriggerDelayAbs_RBV
-      read_widget:
-        type: TextRead
-  - type: Group
-    name: Whitebalance
-    layout:
-      type: Grid
-      labelled: true
-    children:
-    - type: SignalRW
-      name: GCBalRatioSelector
-      description: Select the Red or Blue channel to adjust with 
-        BalanceRatioAbs.
-      write_pv: $(P)$(R)GC_BalRatioSelector
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_BalRatioSelector_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBalanceRatioAbs
-      description: Adjust the gain of the red or blue channel (see 
-        BalanceRatioSelector). The green channel gain is always 1.00.
-      write_pv: $(P)$(R)GC_BalanceRatioAbs
-      write_widget:
-        type: TextWrite
-      read_pv: $(P)$(R)GC_BalanceRatioAbs_RBV
-      read_widget:
-        type: TextRead
-    - type: SignalRW
-      name: GCBalanceWhiteAuto
-      description: 'Method used to set White Balance values. Off: automatic mode is
-        off. Once: auto-whitebalance occurs until target is achieved, then BalanceWhiteAuto
-        returns to Off. Continuous: auto-whitebalance always runs.'
-      write_pv: $(P)$(R)GC_BalanceWhiteAuto
-      write_widget:
-        type: ComboBox
-      read_pv: $(P)$(R)GC_BalanceWhiteAuto_RBV
-      read_widget:
-        type: TextRead
+  - type: SignalRW
+    name: GCAcquisitionStart
+    write_pv: $(P)$(R)GC_AcquisitionStart
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_AcquisitionStart_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalX
+    name: GCAcquisitionStop
+    description: Stop acquisition. Acquisition will stop after acquisition of 
+      the current frame is complete.
+    write_pv: $(P)$(R)GC_AcquisitionStop
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalX
+    name: GCAcquisitionAbort
+    description: Abort acquisition. Acquisition will stop immediately, but a 
+      partially transferred image will be completed.
+    write_pv: $(P)$(R)GC_AcquisitionAbort
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalRW
+    name: GCAcquisitionMode
+    description: 'The acquisition mode determines the behavior of the camera when
+      acquisition start is triggered. "Continuous" mode: the camera will acquire images
+      until acquisition stop is triggered. "SingleFrame" mode: the camera will acquire
+      a single image. "MultiFrame" mode: the camera will acquire the number of images
+      specified by AcquisitionFrameCount. "Recorder" mode: the camera will run continuously,
+      and when the recorder event is triggered, send pre-trigger and post-trigger
+      images to the host.'
+    write_pv: $(P)$(R)GC_AcquisitionMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_AcquisitionMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCAcqFrameCount
+    description: This is the number of images to acquire when in MultiFrame and 
+      Recorder acquisition modes.
+    write_pv: $(P)$(R)GC_AcqFrameCount
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_AcqFrameCount_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCAcqFrameRateAbs
+    description: Frame rate, in frames per second. This is applicable when 
+      either the FrameStart trigger mode is disabled, or the FrameStart trigger 
+      source is FixedRate. Depending on the exposure duration, the camera may 
+      not achieve the frame rate set here.
+    write_pv: $(P)$(R)GC_AcqFrameRateAbs
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_AcqFrameRateAbs_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCAcqFrameRateLimit
+    description: This is the maximum frame rate possible for the current 
+      exposure duration and image format.
+    write_pv: $(P)$(R)GC_AcqFrameRateLimit
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_AcqFrameRateLimit_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCRecPreEventCount
+    description: This is the number of pre-event images to acquire in the 
+      Recorder acquisition mode. This must be less than or equal to 
+      AcquisitionFrameCount.
+    write_pv: $(P)$(R)GC_RecPreEventCount
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_RecPreEventCount_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: BalanceWhiteAutoControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCBalWhiteAutoRate
+    description: Rate of white balance adjustments, from 1 (slowest) to 100 
+      (fastest). Use this control to slow down the auto-whitebalance 
+      adjustments.
+    write_pv: $(P)$(R)GC_BalWhiteAutoRate
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BalWhiteAutoRate_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBalWhiAutAdjTol
+    description: Tolerance, in percent, allowed from the ideal whitebalance 
+      values, within which the auto-whitebalance does not run. This prevents 
+      needless small adjustments from occurring each image.
+    write_pv: $(P)$(R)GC_BalWhiAutAdjTol
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BalWhiAutAdjTol_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: BlackLevelControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCBlaLevelSelector
+    description: Selects which Black Level is controlled by the various Black 
+      Level features.
+    write_pv: $(P)$(R)GC_BlaLevelSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_BlaLevelSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBlackLevel
+    description: Black level (offset) value.
+    write_pv: $(P)$(R)GC_BlackLevel
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BlackLevel_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: ColorTransformationControl
+  description: Category that contains the Color Transformation control features.
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCColTraSelector
+    description: Selects which Color Transformation module is controlled by the 
+      various Color Transformation features.
+    write_pv: $(P)$(R)GC_ColTraSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ColTraSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCColTraMode
+    description: Selects the mode for the color transformation.
+    write_pv: $(P)$(R)GC_ColTraMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ColTraMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCColTraValSelector
+    description: Selects the Gain factor or Offset of the Transformation matrix 
+      to access in the selected Color Transformation module.
+    write_pv: $(P)$(R)GC_ColTraValSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ColTraValSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCColTraValue
+    description: Represents the value of the selected Gain factor or Offset 
+      inside the Transformation matrix.
+    write_pv: $(P)$(R)GC_ColTraValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ColTraValue_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Controls
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCGamma
+    description: Applies gamma value to the raw sensor signal.
+    write_pv: $(P)$(R)GC_Gamma
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Gamma_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDefectMaskEnable
+    description: Enable masking of defective pixel clusters. Defective pixels 
+      are detected and recorded at the factory.
+    write_pv: $(P)$(R)GC_DefectMaskEnable
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DefectMaskEnable_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCHue
+    description: Hue turns the color vectors in the U/V plane. It is 1 degree 
+      per step.
+    write_pv: $(P)$(R)GC_Hue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Hue_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSaturation
+    description: Saturation puts gain to the color vectors in the U/V plane.
+    write_pv: $(P)$(R)GC_Saturation
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Saturation_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: DSPSubregion
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCDSPSubregionLeft
+    description: The DSP subregion is the area of the image used for 
+      measurements in "auto-" functions such as auto-exposure and auto-gain. 
+      DSPSubregionLeft is the left column, relative to the current image region.
+    write_pv: $(P)$(R)GC_DSPSubregionLeft
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DSPSubregionLeft_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDSPSubregionTop
+    description: The DSP subregion is the area of the image used for 
+      measurements in "auto-" functions such as auto-exposure and auto-gain. 
+      DSPSubregionTop is the top row, relative to the current image region.
+    write_pv: $(P)$(R)GC_DSPSubregionTop
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DSPSubregionTop_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDSPSubregionRight
+    description: The DSP subregion is the area of the image used for 
+      measurements in "auto-" functions such as auto-exposure and auto-gain. 
+      DSPSubregionRight is the right column, relative to the current image 
+      region. For convenience, this value may be higher than the maximum Width.
+    write_pv: $(P)$(R)GC_DSPSubregionRight
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DSPSubregionRight_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDSPSubBottom
+    description: The DSP subregion is the area of the image used for 
+      measurements in "auto-" functions such as auto-exposure and auto-gain. 
+      DSPSubregionBottom is the bottom row, relative to the current image 
+      region. For convenience, this value may be higher than the maximum Height.
+    write_pv: $(P)$(R)GC_DSPSubBottom
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DSPSubBottom_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: DefectMask
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCDefMasColEnable
+    description: Enable masking of defective columns. Defective columns are 
+      detected and recorded at the factory.
+    write_pv: $(P)$(R)GC_DefMasColEnable
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_DefMasColEnable_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: DeviceStatus
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCDevTemSelector
+    write_pv: $(P)$(R)GC_DevTemSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_DevTemSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDeviceTemperature
+    write_pv: $(P)$(R)GC_DeviceTemperature
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DeviceTemperature_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: EventControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCEventSelector
+    description: Activate event-notification on the GigE Vision message channel.
+    write_pv: $(P)$(R)GC_EventSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_EventSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventNotification
+    description: Activate event-notification on the GigE Vision message channel.
+    write_pv: $(P)$(R)GC_EventNotification
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_EventNotification_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventsEnable1
+    description: Activate event-notification on the GigE Vision message channel.
+      For programmers. See register documentation.
+    write_pv: $(P)$(R)GC_EventsEnable1
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EventsEnable1_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: EventID
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCEveAcqStart
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveAcqStart
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveAcqStart_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveAcquisitionEnd
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveAcquisitionEnd
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveAcquisitionEnd_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventFrameTrigger
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EventFrameTrigger
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EventFrameTrigger_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventExposureEnd
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EventExposureEnd
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EventExposureEnd_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveAcqRecTrigger
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveAcqRecTrigger
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveAcqRecTrigger_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveLinRisingEdge
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveLinRisingEdge
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveLinRisingEdge_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveLinFallingEdge
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveLinFallingEdge
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveLinFallingEdge_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveLinRisingEdge0
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveLinRisingEdge0
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveLinRisingEdge0_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveLinFallingEdg0
+    description: ID value of event.
+    write_pv: $(P)$(R)GC_EveLinFallingEdg0
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveLinFallingEdg0_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveFraTriReady
+    description: ID value of Frame Trigger Ready event. The Frame Trigger event 
+      occurs when the camera is ready for another frame aquisition
+    write_pv: $(P)$(R)GC_EveFraTriReady
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveFraTriReady_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEveExposureStart
+    write_pv: $(P)$(R)GC_EveExposureStart
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EveExposureStart_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventOverflow
+    description: ID value of overflow event. The overflow event occurs when one 
+      or more notification events are lost on the camera. If you use the message
+      channel for event notification, you are always subscribed to this event.
+    write_pv: $(P)$(R)GC_EventOverflow
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EventOverflow_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCEventError
+    description: ID value of error event. The error event occurs if there is a 
+      problem on the camera; this event should be reported to technical support.
+      If you use the message channel for event notification, you are always 
+      subscribed to this event.
+    write_pv: $(P)$(R)GC_EventError
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_EventError_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Exposure
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCExposureAuto
+    description: 'Method used to set exposure duration, ExposureTimeAbs in Timed mode.
+      Off: automatic mode is off. Once: auto-exposure occurs until target is achieved,
+      then ExposureAuto returns to Off. Continuous: auto-exposure always runs.'
+    write_pv: $(P)$(R)GC_ExposureAuto
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ExposureAuto_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureMode
+    description: 'Method of control for exposure duration. Timed: exposure duration
+      is set by ExposureTimeAbs. TriggerWidth: exposure controlled by external trigger
+      pulse.'
+    write_pv: $(P)$(R)GC_ExposureMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ExposureMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureTimeAbs
+    description: 'Exposure duration in microseconds. Timed: Sensor integration time.
+      TriggerWidth: Ignored.'
+    write_pv: $(P)$(R)GC_ExposureTimeAbs
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExposureTimeAbs_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExpTimeIncrement
+    description: Increment of the exposure time in microseconds.
+    write_pv: $(P)$(R)GC_ExpTimeIncrement
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExpTimeIncrement_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: ExposureAutoControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCExpAutoTarget
+    description: When ExposureAutoAlg is Mean, this is the target image mean 
+      value, in percent. Higher values result in brighter images.
+    write_pv: $(P)$(R)GC_ExpAutoTarget
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExpAutoTarget_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureAutoAlg
+    description: 'Algorithm used for auto-exposure. Mean: target a particular mean
+      value of all measured pixels in the image. FitRange: adjust the maximum pixel
+      value to fit the sensor range.'
+    write_pv: $(P)$(R)GC_ExposureAutoAlg
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ExposureAutoAlg_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureAutoMin
+    description: Minimum auto-exposure value, in microseconds.
+    write_pv: $(P)$(R)GC_ExposureAutoMin
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExposureAutoMin_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureAutoMax
+    description: Maximum auto-exposure value, in microseconds.
+    write_pv: $(P)$(R)GC_ExposureAutoMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExposureAutoMax_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureAutoRate
+    description: Rate of exposure adjustments, from 1 (slowest) to 100 
+      (fastest). Use this control to slow down the auto-exposure adjustments.
+    write_pv: $(P)$(R)GC_ExposureAutoRate
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExposureAutoRate_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExpAutoOutliers
+    description: Number of upper outliers to discard before calculating exposure
+      adjustments. This is in ten-thousandths of the number pixels in the image.
+    write_pv: $(P)$(R)GC_ExpAutoOutliers
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExpAutoOutliers_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExpAutoAdjustTol
+    description: Tolerance, in percent, allowed from the ideal exposure value, 
+      within which the auto-exposure does not run. This prevents needless small 
+      adjustments from occurring each image.
+    write_pv: $(P)$(R)GC_ExpAutoAdjustTol
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExpAutoAdjustTol_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: GainAutoControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCGainAutoTarget
+    description: This is the target image mean value, in percent.
+    write_pv: $(P)$(R)GC_GainAutoTarget
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoTarget_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAutoMin
+    write_pv: $(P)$(R)GC_GainAutoMin
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoMin_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAutoMax
+    write_pv: $(P)$(R)GC_GainAutoMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoMax_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAutoRate
+    description: Rate of gain adjustments, from 1 (slowest) to 100 (fastest). 
+      Use this control to slow down the auto-gain adjustments.
+    write_pv: $(P)$(R)GC_GainAutoRate
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoRate_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAutoOutliers
+    description: Number of upper outliers to discard before calculating gain 
+      adjustments. This is in ten-thousandths of the number pixels in the image.
+    write_pv: $(P)$(R)GC_GainAutoOutliers
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoOutliers_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAutoAdjustTol
+    description: Tolerance, in percent, allowed from the ideal gain value, 
+      within which the auto-gain does not run. This prevents needless small 
+      adjustments from occurring each image.
+    write_pv: $(P)$(R)GC_GainAutoAdjustTol
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainAutoAdjustTol_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: GainControl
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCGainSelector
+    description: (GenICam boilerplate. Always All.)
+    write_pv: $(P)$(R)GC_GainSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_GainSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGain
+    description: Gain value of analog A/D stage. Units are usually in dB.
+    write_pv: $(P)$(R)GC_Gain
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Gain_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainRaw
+    description: Gain value of analog A/D stage. Units are usually in dB.
+    write_pv: $(P)$(R)GC_GainRaw
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GainRaw_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGainAuto
+    description: 'Method used to set Gain. Off: automatic mode is off. Once: auto-gain
+      occurs until target is achieved, then GainAuto returns to Off. Continuous: auto-gain
+      always runs.'
+    write_pv: $(P)$(R)GC_GainAuto
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_GainAuto_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: GigE
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCStrBytesPerSecond
+    write_pv: $(P)$(R)GC_StrBytesPerSecond
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_StrBytesPerSecond_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBanControlMode
+    description: Bandwidth allocation can be controlled by StreamBytesPerSecond,
+      or by register SCPD0. If you do not understand SCPD0 and how this driver 
+      uses this register, leave this set to "StreamBytesPerSecond".
+    write_pv: $(P)$(R)GC_BanControlMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_BanControlMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCGevSCPSPacketSize
+    write_pv: $(P)$(R)GC_GevSCPSPacketSize
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GevSCPSPacketSize_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCChunkModeActive
+    write_pv: $(P)$(R)GC_ChunkModeActive
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ChunkModeActive_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPayloadSize
+    description: Maximum size of image block payload.
+    write_pv: $(P)$(R)GC_PayloadSize
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_PayloadSize_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCNonImaPayloadSize
+    description: Maximum size of chunk data, not including the image chunk, in 
+      the image block payload.
+    write_pv: $(P)$(R)GC_NonImaPayloadSize
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_NonImaPayloadSize_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCStrFraRatCon
+    description: When enabled, the frame rate of the camera is constrained by 
+      available bandwidth. When disabled, the camera can image faster than it 
+      can send data.
+    write_pv: $(P)$(R)GC_StrFraRatCon
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_StrFraRatCon_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: ImageFormat
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCWidthMax
+    description: Maximum image width for the current image mode. Horizontal 
+      binning, for example, will change this value.
+    write_pv: $(P)$(R)GC_WidthMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_WidthMax_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCHeightMax
+    description: Maximum image height for the current image mode. Vertical 
+      binning, for example, will change this value.
+    write_pv: $(P)$(R)GC_HeightMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_HeightMax_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPixelFormat
+    description: Format of the image data.
+    write_pv: $(P)$(R)GC_PixelFormat
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_PixelFormat_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSensorReadoutMode
+    description: Readout Mode of the sensor.
+    write_pv: $(P)$(R)GC_SensorReadoutMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SensorReadoutMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCWidth
+    description: Width of image, in pixels.
+    write_pv: $(P)$(R)GC_Width
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Width_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCHeight
+    description: Height of image, in pixels.
+    write_pv: $(P)$(R)GC_Height
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_Height_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCOffsetX
+    description: Starting column of the readout region (relative to the first 
+      column of the sensor) in pixels.
+    write_pv: $(P)$(R)GC_OffsetX
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_OffsetX_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCOffsetY
+    description: Starting row of the readout region (relative to the first row 
+      of the sensor) in pixels.
+    write_pv: $(P)$(R)GC_OffsetY
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_OffsetY_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCImageSize
+    description: Size of images, in bytes, for the current format and size.
+    write_pv: $(P)$(R)GC_ImageSize
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ImageSize_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: ImageMode
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCSensorWidth
+    description: Full width of image sensor.
+    write_pv: $(P)$(R)GC_SensorWidth
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SensorWidth_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSensorHeight
+    description: Full height of image sensor.
+    write_pv: $(P)$(R)GC_SensorHeight
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SensorHeight_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSensorTaps
+    description: Number of taps of the camera sensor.
+    write_pv: $(P)$(R)GC_SensorTaps
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SensorTaps_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSenDigTaps
+    description: Number of digitized samples outputted simultaneously by the 
+      camera A/D conversion stage.
+    write_pv: $(P)$(R)GC_SenDigTaps
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SenDigTaps_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBinningHorizontal
+    description: Binning in horizontal direction. Binning is the summing of 
+      charge of adjacent pixels.
+    write_pv: $(P)$(R)GC_BinningHorizontal
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BinningHorizontal_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBinningVertical
+    description: Binning in vertical direction. Binning is the summing of charge
+      of adjacent pixels.
+    write_pv: $(P)$(R)GC_BinningVertical
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BinningVertical_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDecHorizontal
+    description: Horizontal decimation (sub-sampling) of the image.
+    write_pv: $(P)$(R)GC_DecHorizontal
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DecHorizontal_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDecVertical
+    description: Vertical decimation (sub-sampling) of the image.
+    write_pv: $(P)$(R)GC_DecVertical
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DecVertical_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCReverseX
+    description: ReverseX is used to flip horizontally the image sent by the 
+      device. The AOI is applied after the flipping.
+    write_pv: $(P)$(R)GC_ReverseX
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ReverseX_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCReverseY
+    description: ReverseY is used to flip vertically the image sent by the 
+      device. The AOI is applied after the flipping.
+    write_pv: $(P)$(R)GC_ReverseY
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ReverseY_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Info
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCFirmwareVerMajor
+    write_pv: $(P)$(R)GC_FirmwareVerMajor
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_FirmwareVerMajor_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCFirmwareVerMinor
+    write_pv: $(P)$(R)GC_FirmwareVerMinor
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_FirmwareVerMinor_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCFirmwareVerBuild
+    write_pv: $(P)$(R)GC_FirmwareVerBuild
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_FirmwareVerBuild_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSensorType
+    description: Type of image sensor.
+    write_pv: $(P)$(R)GC_SensorType
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SensorType_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSensorBits
+    description: Maximum bit depth of sensor.
+    write_pv: $(P)$(R)GC_SensorBits
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SensorBits_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCDeviceVendorName
+    read_pv: $(P)$(R)GC_DeviceVendorName
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCDeviceModelName
+    description: Camera model name.
+    read_pv: $(P)$(R)GC_DeviceModelName
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCDevFirVersion
+    description: Firmware version of this AVT GigE camera.
+    read_pv: $(P)$(R)GC_DevFirVersion
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCDeviceID
+    description: Serial number.
+    read_pv: $(P)$(R)GC_DeviceID
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDeviceUserID
+    description: User-programmable Device Identifier.
+    write_pv: $(P)$(R)GC_DeviceUserID
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_DeviceUserID_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCDevicePartNumber
+    description: Device part number.
+    read_pv: $(P)$(R)GC_DevicePartNumber
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCDeviceScanType
+    write_pv: $(P)$(R)GC_DeviceScanType
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_DeviceScanType_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Iris
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCIrisMode
+    description: 'Set the iris mode. Disabled: no iris control. Video: enable video
+      iris. VideoOpen: fully open a video iris. VideoClose: fully close a video iris.'
+    write_pv: $(P)$(R)GC_IrisMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_IrisMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCIrisAutoTarget
+    description: This is the target image mean value, in percent.
+    write_pv: $(P)$(R)GC_IrisAutoTarget
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_IrisAutoTarget_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCIrisVideoLevel
+    description: Current video-iris level, in approximately mV pp; read only. 
+      When calibrating a video lens, this value should fall between 
+      IrisVideoLevelMin and IrisVideoLevelMax.
+    write_pv: $(P)$(R)GC_IrisVideoLevel
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_IrisVideoLevel_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCIrisVideoLevelMin
+    description: Minimum video iris level output by the camera, in approximately
+      mV pp. A higher minimum value slows the adjustment time but prevents 
+      excessive overshoot.
+    write_pv: $(P)$(R)GC_IrisVideoLevelMin
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_IrisVideoLevelMin_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCIrisVideoLevelMax
+    description: Maximum video iris level output by the camera, in approximately
+      mV pp. A lower minimum value slows the adjustment time but prevents 
+      excessive overshoot.
+    write_pv: $(P)$(R)GC_IrisVideoLevelMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_IrisVideoLevelMax_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: LUTControl
+  description: Category that includes the LUT control features.
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCLUTSelector
+    description: Selects which look up table is used.
+    write_pv: $(P)$(R)GC_LUTSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_LUTSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTMode
+    description: Selects which mode is used for the selected look up table.
+    write_pv: $(P)$(R)GC_LUTMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_LUTMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTEnable
+    description: Activates the selected LUT.
+    write_pv: $(P)$(R)GC_LUTEnable
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTEnable_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTIndex
+    description: Control the index of the coefficient to access in the selected 
+      look up table.
+    write_pv: $(P)$(R)GC_LUTIndex
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTIndex_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTValue
+    description: Returns the Value at entry LUTIndex of the selected look up 
+      table
+    write_pv: $(P)$(R)GC_LUTValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTValue_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalX
+    name: GCLUTLoadAll
+    description: Load all look up tables from Flash.
+    write_pv: $(P)$(R)GC_LUTLoadAll
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalX
+    name: GCLUTSaveAll
+    description: Save all look up tables in Flash.
+    write_pv: $(P)$(R)GC_LUTSaveAll
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+- type: Group
+  name: LUTInfo
+  description: Category that includes the LUT info features for the look up 
+    table.
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCLUTBitDepthIn
+    description: Bit length of the input value of the look up table block
+    write_pv: $(P)$(R)GC_LUTBitDepthIn
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTBitDepthIn_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTBitDepthOut
+    description: Bit length of the output value of the look up table block
+    write_pv: $(P)$(R)GC_LUTBitDepthOut
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTBitDepthOut_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTAddress
+    description: Address of the memory area where the selected LUT is located 
+      (for raw memory transfer)
+    write_pv: $(P)$(R)GC_LUTAddress
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTAddress_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLUTSizeBytes
+    description: Size of the memory area where the LUT is located
+    write_pv: $(P)$(R)GC_LUTSizeBytes
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LUTSizeBytes_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: LensDCIris
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCLenDCDriStrength
+    write_pv: $(P)$(R)GC_LenDCDriStrength
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LenDCDriStrength_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: LensPIris
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCLenPIrisFrequency
+    write_pv: $(P)$(R)GC_LenPIrisFrequency
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LenPIrisFrequency_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLensPIrisNumSteps
+    write_pv: $(P)$(R)GC_LensPIrisNumSteps
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LensPIrisNumSteps_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCLensPIrisPosition
+    write_pv: $(P)$(R)GC_LensPIrisPosition
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_LensPIrisPosition_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: PvApi
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCPvDumTriSelector
+    write_pv: $(P)$(R)GC_PvDumTriSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_PvDumTriSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPvDumFraStaTriMod
+    write_pv: $(P)$(R)GC_PvDumFraStaTriMod
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_PvDumFraStaTriMod_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPvDumTriggerMode
+    write_pv: $(P)$(R)GC_PvDumTriggerMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_PvDumTriggerMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCFraStaTriDelay
+    write_pv: $(P)$(R)GC_FraStaTriDelay
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_FraStaTriDelay_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureModeValue
+    description: 'Method of control for exposure duration. Timed: exposure duration
+      is set by ExposureValue. AutoOnce: auto-exposure occurs until target is achieved,
+      then ExposureMode returns to Timed. Auto: auto-exposure always runs. TriggerWidth:
+      exposure controlled by external trigger pulse.'
+    write_pv: $(P)$(R)GC_ExposureModeValue
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_ExposureModeValue_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCExposureValue
+    description: 'Exposure duration, in microseconds. Timed: Sensor integration time.
+      TriggerWidth: Ignored.'
+    write_pv: $(P)$(R)GC_ExposureValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_ExposureValue_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTimeStampValueLo
+    description: Low-word value of timestamp, when latched by 
+      GevTimestampControlLatch.
+    write_pv: $(P)$(R)GC_TimeStampValueLo
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_TimeStampValueLo_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTimeStampValueHi
+    description: High-word value of timestamp, when latched by 
+      GevTimestampControlLatch.
+    write_pv: $(P)$(R)GC_TimeStampValueHi
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_TimeStampValueHi_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCWhitebalValueRed
+    write_pv: $(P)$(R)GC_WhitebalValueRed
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_WhitebalValueRed_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCWhitebalValueBlue
+    write_pv: $(P)$(R)GC_WhitebalValueBlue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_WhitebalValueBlue_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalR
+    name: GCModelName
+    read_pv: $(P)$(R)GC_ModelName
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPvGainRaw
+    description: Gain value of analog A/D stage. Units are usually in dB.
+    write_pv: $(P)$(R)GC_PvGainRaw
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_PvGainRaw_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPvGainAutoMin
+    description: Minimum auto-gain value.
+    write_pv: $(P)$(R)GC_PvGainAutoMin
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_PvGainAutoMin_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCPvGainAutoMax
+    description: Maximum auto-gain value.
+    write_pv: $(P)$(R)GC_PvGainAutoMax
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_PvGainAutoMax_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCOffsetValue
+    description: Black level (offset) value.
+    write_pv: $(P)$(R)GC_OffsetValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_OffsetValue_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: SavedUserSets
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCUserSetSelector
+    description: Select a user set, for loading or saving camera parameters.
+    write_pv: $(P)$(R)GC_UserSetSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_UserSetSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalX
+    name: GCUserSetLoad
+    description: Load camera parameters from the user set specified by 
+      UserSetSelector.
+    write_pv: $(P)$(R)GC_UserSetLoad
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalX
+    name: GCUserSetSave
+    description: Save camera parameters to the user set specified by 
+      UserSetSelector.
+    write_pv: $(P)$(R)GC_UserSetSave
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalRW
+    name: GCUseSetDefSelector
+    description: On power-up or reset, this user set is loaded.
+    write_pv: $(P)$(R)GC_UseSetDefSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_UseSetDefSelector_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: StreamHold
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCStreamHoldEnable
+    description: Control on-camera image storage; this control is like a "pause"
+      button for the image stream. When enabled, images remain stored on the 
+      camera, and are not transmitted to the host. When disabled, the image 
+      stream resumes, and any stored images are sent to the host.
+    write_pv: $(P)$(R)GC_StreamHoldEnable
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_StreamHoldEnable_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCStrHoldCapacity
+    description: Maximum number of images (for the current size and format) 
+      which can be stored on the camera when StreamHold is enabled.
+    write_pv: $(P)$(R)GC_StrHoldCapacity
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_StrHoldCapacity_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Strobe
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCStrobeSource
+    description: Signal source of the strobe timing unit. See SyncOutSource for 
+      descriptions.
+    write_pv: $(P)$(R)GC_StrobeSource
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_StrobeSource_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCStrDurationMode
+    description: 'Mode of the strobe timing unit. Source: strobe duration is the same
+      as source duration. Controlled: strobe duration is set by StrobeDuration.'
+    write_pv: $(P)$(R)GC_StrDurationMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_StrDurationMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCStrobeDelay
+    description: Delay from strobe trigger to strobe output, in microseconds.
+    write_pv: $(P)$(R)GC_StrobeDelay
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_StrobeDelay_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCStrobeDuration
+    description: Duration of strobe, in microseconds.
+    write_pv: $(P)$(R)GC_StrobeDuration
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_StrobeDuration_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: SubstrateVoltage
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCVsubValue
+    description: Substrate voltage in mV.
+    write_pv: $(P)$(R)GC_VsubValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_VsubValue_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: SyncIn
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCSyncInLevels
+    description: Momentary logic levels of the hardware line inputs.
+    write_pv: $(P)$(R)GC_SyncInLevels
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SyncInLevels_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSyncInSelector
+    description: Select the sync-in line to control with {SyncInGlitchFilter}.
+    write_pv: $(P)$(R)GC_SyncInSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SyncInSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSynInGlitchFilter
+    description: Glitch filter on sync-in line, in nanoseconds.
+    write_pv: $(P)$(R)GC_SynInGlitchFilter
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SynInGlitchFilter_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: SyncOut
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCSyncOutLevels
+    description: 'Output levels of hardware sync outputs, for output(s) in GPO mode.
+      (Note: SyncOutPolarity can invert these values.)'
+    write_pv: $(P)$(R)GC_SyncOutLevels
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SyncOutLevels_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSyncOutSelector
+    description: Select the sync-out line to control with {SyncOutSource, 
+      SyncOutPolarity}.
+    write_pv: $(P)$(R)GC_SyncOutSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SyncOutSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSyncOutSource
+    description: 'Signal source of the sync-out line specified by SyncOutSelector.
+      GPO: general purpose output. AcquisitionTriggerReady: acquisition trigger may
+      occur. FrameTriggerReady: frame trigger may occur. Exposing: exposure in progress.
+      FrameReadout: image readout in progress. Imaging: exposure or frame readout
+      in progress. Acquiring: acquisition is running. LineIn: external line input.
+      Strobe: source is strobe timing unit.'
+    write_pv: $(P)$(R)GC_SyncOutSource
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SyncOutSource_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCSyncOutPolarity
+    description: Polarity applied to the sync-out line specified by 
+      SyncOutSelector.
+    write_pv: $(P)$(R)GC_SyncOutPolarity
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_SyncOutPolarity_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Timestamp
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCGevTimTicFre
+    description: Frequency of image timestamp, in Hertz.
+    write_pv: $(P)$(R)GC_GevTimTicFre
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GevTimTicFre_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalX
+    name: GCGevTimConLatch
+    description: Capture timestamp and store in GevTimestampValue.
+    write_pv: $(P)$(R)GC_GevTimConLatch
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalX
+    name: GCGevTimConReset
+    description: Reset the timestamp.
+    write_pv: $(P)$(R)GC_GevTimConReset
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalRW
+    name: GCGevTimestampValue
+    description: Value of timestamp, when latched by GevTimestampControlLatch.
+    write_pv: $(P)$(R)GC_GevTimestampValue
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_GevTimestampValue_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Trigger
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCTriggerSelector
+    description: Select a trigger here, then use the controls {TriggerMode, 
+      TriggerSoftware, TriggerSource, TriggerActivation, TriggerOverlap, 
+      TriggerDelayAbs} to setup and read the trigger attributes. FrameStart is 
+      the trigger which starts each image (when acquisition is running). 
+      AcquisitionStart is the trigger which starts the acquisition process.
+    write_pv: $(P)$(R)GC_TriggerSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_TriggerSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTriggerMode
+    description: 'Enable or disable this trigger. Note: when the FrameStart trigger
+      is disabled, images are triggered at a fixed rate specified by AcquisitionFrameRateAbs.'
+    write_pv: $(P)$(R)GC_TriggerMode
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_TriggerMode_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalX
+    name: GCTriggerSoftware
+    description: This software command effects a trigger.
+    write_pv: $(P)$(R)GC_TriggerSoftware
+    write_widget:
+      type: ButtonPanel
+      actions:
+        Go: '1'
+    value: '1'
+  - type: SignalRW
+    name: GCTriggerSource
+    description: Source of trigger, when TriggerMode is On. This might be an 
+      hardware trigger, a fixed rate generator, or software trigger only.
+    write_pv: $(P)$(R)GC_TriggerSource
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_TriggerSource_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTriggerActivation
+    description: Type of activation, for hardware triggers. This controls 
+      edge/level and polarity sensitivities.
+    write_pv: $(P)$(R)GC_TriggerActivation
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_TriggerActivation_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTriggerOverlap
+    description: Permitted window of trigger activation, relative to previous 
+      frame.
+    write_pv: $(P)$(R)GC_TriggerOverlap
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_TriggerOverlap_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCTriggerDelayAbs
+    description: Delay from hardware trigger activation to trigger effect, in 
+      microseconds.
+    write_pv: $(P)$(R)GC_TriggerDelayAbs
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_TriggerDelayAbs_RBV
+    read_widget:
+      type: TextRead
+- type: Group
+  name: Whitebalance
+  layout:
+    type: Grid
+    labelled: true
+  children:
+  - type: SignalRW
+    name: GCBalRatioSelector
+    description: Select the Red or Blue channel to adjust with BalanceRatioAbs.
+    write_pv: $(P)$(R)GC_BalRatioSelector
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_BalRatioSelector_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBalanceRatioAbs
+    description: Adjust the gain of the red or blue channel (see 
+      BalanceRatioSelector). The green channel gain is always 1.00.
+    write_pv: $(P)$(R)GC_BalanceRatioAbs
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_BalanceRatioAbs_RBV
+    read_widget:
+      type: TextRead
+  - type: SignalRW
+    name: GCBalanceWhiteAuto
+    description: 'Method used to set White Balance values. Off: automatic mode is
+      off. Once: auto-whitebalance occurs until target is achieved, then BalanceWhiteAuto
+      returns to Off. Continuous: auto-whitebalance always runs.'
+    write_pv: $(P)$(R)GC_BalanceWhiteAuto
+    write_widget:
+      type: ComboBox
+    read_pv: $(P)$(R)GC_BalanceWhiteAuto_RBV
+    read_widget:
+      type: TextRead

--- a/python-tests/NewInstanceClassPVIYamlCreatedWithMakePvi.pvi.device.yaml
+++ b/python-tests/NewInstanceClassPVIYamlCreatedWithMakePvi.pvi.device.yaml
@@ -7,14 +7,12 @@ children:
   layout:
     type: Grid
     labelled: true
-    stacked: false
   children:
   - type: Group
     name: Acquisition
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCAcquisitionStart
@@ -107,7 +105,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCBalWhiteAutoRate
@@ -136,7 +133,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCBlaLevelSelector
@@ -164,7 +160,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCColTraSelector
@@ -210,7 +205,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCGamma
@@ -255,7 +249,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCDSPSubregionLeft
@@ -311,7 +304,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCDefMasColEnable
@@ -328,7 +320,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCDevTemSelector
@@ -351,7 +342,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCEventSelector
@@ -388,7 +378,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCEveAcqStart
@@ -518,7 +507,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCExposureAuto
@@ -567,7 +555,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCExpAutoTarget
@@ -645,7 +632,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCGainAutoTarget
@@ -709,7 +695,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCGainSelector
@@ -754,7 +739,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCStrBytesPerSecond
@@ -827,7 +811,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCWidthMax
@@ -919,7 +902,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCSensorWidth
@@ -1021,7 +1003,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCFirmwareVerMajor
@@ -1116,7 +1097,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCIrisMode
@@ -1177,7 +1157,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCLUTSelector
@@ -1251,7 +1230,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCLUTBitDepthIn
@@ -1295,7 +1273,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCLenDCDriStrength
@@ -1310,7 +1287,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCLenPIrisFrequency
@@ -1341,7 +1317,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCPvDumTriSelector
@@ -1479,7 +1454,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCUserSetSelector
@@ -1524,7 +1498,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCStreamHoldEnable
@@ -1553,7 +1526,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCStrobeSource
@@ -1598,7 +1570,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCVsubValue
@@ -1614,7 +1585,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCSyncInLevels
@@ -1648,7 +1618,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCSyncOutLevels
@@ -1699,7 +1668,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCGevTimTicFre
@@ -1742,7 +1710,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCTriggerSelector
@@ -1821,7 +1788,6 @@ children:
     layout:
       type: Grid
       labelled: true
-      stacked: false
     children:
     - type: SignalRW
       name: GCBalRatioSelector

--- a/python-tests/dls.bob.pvi.formatter.yaml
+++ b/python-tests/dls.bob.pvi.formatter.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../schemas/pvi.formatter.schema.json
+type: DLSFormatter
+# Remove screen property to use default value
+spacing: 4
+title_height: 26
+max_height: 900
+label_width: 120
+widget_width: 120
+widget_height: 20

--- a/python-tests/test_makePvi.py
+++ b/python-tests/test_makePvi.py
@@ -204,11 +204,7 @@ class TestPviModel:
         # Device label
         assert data["label"] == "Camera test label"
 
-        children = data["children"]
-        assert len(children) == 1
-
-        root = children[0]
-        groups = root["children"]
+        groups = data["children"]
         assert len(groups) == 2
 
         group_names = [g["name"] for g in groups]


### PR DESCRIPTION
Modified makePvi.py to remove the followings from the PVI yaml at the top level

-` type: Device`
-`- parent: NewInstanceClassPVIYamlCreatedWithMakePvi`
- the top level group
```
 children:
- - type: Group
-   name: NewInstanceClassPVIYamlCreatedWithMakePvi
```
Also added example of output .bob file.