### PR TITLE
Fix start.sh for AutoGeniCam class or not logic

### DIFF
--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -80,18 +80,18 @@ for ((count = 0 ; count < ${#entities[@]}; count++ )); do # Iterate over each en
 
     instance_class=$(yq ".entities[${count}].CLASS" "${ibek_src}")
     instance_id=$(yq ".entities[${count}].ID" "${ibek_src}")
+    output_file_name_root="${instance_class}-${instance_id}"
     label="GenICam ${instance_id}"
 
     if [[ ${instance_class} != "AutoADGenICam" ]]; then
         # Not AutoADGenICam, generate pvi device from the existing GenICam DB
         template="/epics/support/ADGenICam/db/${instance_class}.template"
-        generate_pvi_from_template "${template}" "${instance_class}" "${label}"
+        generate_pvi_from_template "${template}" "${output_file_name_root}" "${label}"
         continue
     fi   
 
     # Auto generate GenICam database from camera parameters XML
-    instance_class="auto-${instance_id}"
-    template="/epics/support/ADGenICam/db/${instance_class}.template"
+    output_file_name_root="auto-${instance_id}"
     xml_file="/tmp/${instance_id}-genicam.xml"
     arv-tool-0.8 -a "${instance_id}" genicam > "${xml_file}"
 
@@ -100,15 +100,16 @@ for ((count = 0 ; count < ${#entities[@]}; count++ )); do # Iterate over each en
         python /epics/ioc/scripts/makePvi.py \
             "${xml_file}" \
             /epics/pvi-defs/ \
-            --name "${instance_class}" \
+            --name "${output_file_name_root}" \
             --label "${label}"
         continue
     fi
 
     # Can't get xml from camera: make empty GenICam DB and generate pvi device from it
     echo "Can't connect to camera ${instance_id}"
+    template="/epics/support/ADGenICam/db/${output_file_name_root}.template"
     touch "${template}"
-    generate_pvi_from_template "${template}" "${instance_class}" "${label}"
+    generate_pvi_from_template "${template}" "${output_file_name_root}" "${label}"
 done
 
 # get the ibek support yaml files this ioc's support modules

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -58,36 +58,57 @@ fi
 
 # generate template for Aravis cameras parameters ******************************
 
-ibek_src=${CONFIG_DIR}/ioc.yaml
-readarray entities < <(yq -o=j -I=0 '.entities[]' ${ibek_src})
-for ((count = 0 ; count < ${#entities[@]} ; count++ ))  # Iterate over each entity
-do
-    instance_type=$(yq .entities[${count}].type ${ibek_src})
-    if [ $instance_type = "ADAravis.aravisCamera" ]
-    then
-        instance_class=$(yq .entities[${count}].CLASS ${ibek_src})
-        instance_id=$(yq .entities[${count}].ID ${ibek_src})
+generate_pvi_from_template() {
+    local template="$1"
+    local name="$2"
+    local label="$3"
 
-        if [[ $instance_class == "AutoADGenICam" ]]; then
-            instance_class=auto-${instance_id}
-            # Auto generate GenICam database from camera parameters XML
-            arv-tool-0.8 -a ${instance_id} genicam > /tmp/${instance_id}-genicam.xml
-            if [[ ! -s /tmp/${instance_id}-genicam.xml ]]; then
-                # can't contact the camera - make an empty template
-                echo "Can't connect to camera ${instance_id}"
-                touch /epics/support/ADGenICam/db/${instance_class}.template
-            else
-                # make a db file from the GenICam XML
-                python /epics/support/ADGenICam/scripts/makeDb.py /tmp/${instance_id}-genicam.xml /epics/support/ADGenICam/db/${instance_class}.template
-            fi
-        fi
-        # Generate pvi device from the GenICam DB
-        # --name is device class
-        # --label is instance ID
-        python /epics/ioc/scripts/makePvi.py /tmp/${instance_id}-genicam.xml /epics/pvi-defs/ \
-            --name $instance_class \
-            --label "GenICam $instance_id"
+    pvi convert device \
+        --template "${template}" \
+        --name "${name}" \
+        --label "${label}" \
+        /epics/pvi-defs/
+}
+
+ibek_src="${CONFIG_DIR}/ioc.yaml"
+readarray entities < <(yq -o=j -I=0 '.entities[]' "${ibek_src}")
+
+for ((count = 0 ; count < ${#entities[@]}; count++ )); do # Iterate over each entity
+    instance_type=$(yq ".entities[${count}].type" "${ibek_src}")
+
+    [[ ${instance_type} != "ADAravis.aravisCamera" ]] && continue
+
+    instance_class=$(yq ".entities[${count}].CLASS" "${ibek_src}")
+    instance_id=$(yq ".entities[${count}].ID" "${ibek_src}")
+    label="GenICam ${instance_id}"
+
+    if [[ ${instance_class} != "AutoADGenICam" ]]; then
+        # Not AutoADGenICam, generate pvi device from the existing GenICam DB
+        template="/epics/support/ADGenICam/db/${instance_class}.template"
+        generate_pvi_from_template "${template}" "${instance_class}" "${label}"
+        continue
+    fi   
+
+    # Auto generate GenICam database from camera parameters XML
+    instance_class="auto-${instance_id}"
+    template="/epics/support/ADGenICam/db/${instance_class}.template"
+    xml_file="/tmp/${instance_id}-genicam.xml"
+    arv-tool-0.8 -a "${instance_id}" genicam > "${xml_file}"
+
+    if [[ -s ${xml_file} ]]; then
+        # Generate pvi device from xml
+        python /epics/ioc/scripts/makePvi.py \
+            "${xml_file}" \
+            /epics/pvi-defs/ \
+            --name "${instance_class}" \
+            --label "${label}"
+        continue
     fi
+
+    # Can't get xml from camera: make empty GenICam DB and generate pvi device from it
+    echo "Can't connect to camera ${instance_id}"
+    touch "${template}"
+    generate_pvi_from_template "${template}" "${instance_class}" "${label}"
 done
 
 # get the ibek support yaml files this ioc's support modules


### PR DESCRIPTION
The previous version had the wrong logic for Aravis camera with class not equal to AutoGenICam. This is for fixing that.
I also changed the logic for emitting 1 device pvi yaml file per aravis camera. Suppose an IOC has 6 cameras of type "ADAravis.aravisCamera": cameras with IDs 1 and 2 have CLASS "A", cameras with IDs 3 an 4 have CLASS "B", cameras with IDs 5 and 6 have CLASS "AutoADGenICam", the original code would emit:

1. A.pvi.device.yaml
2. B.pvi.device.yaml
3. auto-5.pvi.device.yaml
4. auto-6.pvi.device.yaml

I've changed it to emit:

1. A-1.pvi.device.yaml
2. A-2.pvi.device.yaml
3. B-3.pvi.device.yaml
4. B-4.pvi.device.yaml
5. auto-5.pvi.device.yaml
6. auto-6.pvi.device.yaml
